### PR TITLE
Add hero and footer calendar buttons

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -85,6 +85,22 @@ export default function HomePage() {
             <a href="/registry" className="inline-block rounded-full border border-rose-600 px-8 py-3 font-medium text-rose-700 transition-colors hover:bg-rose-50">
               Registry
             </a>
+            <AddToCalendarButtonClient
+              name={jsonLd.name}
+              startDate="2025-10-10"
+              startTime="16:00"
+              endDate="2025-10-10"
+              endTime="22:00"
+              timeZone="America/Chicago"
+              location="Plummer House, 1091 Plummer Ln SW, Rochester, MN"
+              description={jsonLd.description}
+              options={['Google', 'Apple', 'iCal', 'Outlook.com', 'Yahoo']}
+              buttonStyle="round"
+              label="Add to Calendar"
+              size="2"
+              inline
+              customCss={`:root{--btn-background:linear-gradient(135deg,${COLORS.accentFrom},${COLORS.accentTo});--btn-text:#fff}`}
+            />
           </motion.div>
         </section>
 
@@ -179,6 +195,22 @@ export default function HomePage() {
         <footer className="flex flex-col items-center gap-4 px-4 pb-10 text-sm text-gray-500">
           <p>© {new Date().getFullYear()} Abbigayle & Frederick • Designed with ❤️ in Minnesota</p>
           <a href="/project-info" className="text-rose-600 hover:underline">About this site</a>
+          <AddToCalendarButtonClient
+            name={jsonLd.name}
+            startDate="2025-10-10"
+            startTime="16:00"
+            endDate="2025-10-10"
+            endTime="22:00"
+            timeZone="America/Chicago"
+            location="Plummer House, 1091 Plummer Ln SW, Rochester, MN"
+            description={jsonLd.description}
+            options={['Google', 'Apple', 'iCal', 'Outlook.com', 'Yahoo']}
+            buttonStyle="round"
+            label="Add to Calendar"
+            size="2"
+            inline
+            customCss={`:root{--btn-background:linear-gradient(135deg,${COLORS.accentFrom},${COLORS.accentTo});--btn-text:#fff}`}
+          />
         </footer>
       </div>
     </>


### PR DESCRIPTION
## Summary
- surface Add To Calendar button next to the registry CTA on the main page
- repeat the Add To Calendar button in the footer below the About link

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6862cca15810832c871ac0f3fb528557