### PR TITLE
Add hero and footer calendar buttons

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@
 
 import { Geist } from "next/font/google";
 import "./globals.css";
+import "../styles/add-to-calendar.css";
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation'; // Import useRouter for navigation
 import LoadingScreen from '@/components/LoadingScreen';
@@ -87,3 +88,4 @@ export default function RootLayout({
     </html>
   );
 }
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -85,6 +85,22 @@ export default function HomePage() {
             <a href="/registry" className="inline-block rounded-full border border-rose-600 px-8 py-3 font-medium text-rose-700 transition-colors hover:bg-rose-50">
               Registry
             </a>
+            <AddToCalendarButtonClient
+              name={jsonLd.name}
+              startDate="2025-10-10"
+              startTime="16:00"
+              endDate="2025-10-10"
+              endTime="22:00"
+              timeZone="America/Chicago"
+              location="Plummer House, 1091 Plummer Ln SW, Rochester, MN"
+              description={jsonLd.description}
+              options={['Google', 'Apple', 'iCal', 'Outlook.com', 'Yahoo']}
+              buttonStyle="round"
+              label="Add to Calendar"
+              size="2"
+              inline
+              customCss={`:root{--btn-background:linear-gradient(135deg,${COLORS.accentFrom},${COLORS.accentTo});--btn-text:#fff}`}
+            />
           </motion.div>
         </section>
 
@@ -179,6 +195,22 @@ export default function HomePage() {
         <footer className="flex flex-col items-center gap-4 px-4 pb-10 text-sm text-gray-500">
           <p>© {new Date().getFullYear()} Abbigayle & Frederick • Designed with ❤️ in Minnesota</p>
           <a href="/project-info" className="text-rose-600 hover:underline">About this site</a>
+          <AddToCalendarButtonClient
+            name={jsonLd.name}
+            startDate="2025-10-10"
+            startTime="16:00"
+            endDate="2025-10-10"
+            endTime="22:00"
+            timeZone="America/Chicago"
+            location="Plummer House, 1091 Plummer Ln SW, Rochester, MN"
+            description={jsonLd.description}
+            options={['Google', 'Apple', 'iCal', 'Outlook.com', 'Yahoo']}
+            buttonStyle="round"
+            label="Add to Calendar"
+            size="2"
+            inline
+            customCss={`:root{--btn-background:linear-gradient(135deg,${COLORS.accentFrom},${COLORS.accentTo});--btn-text:#fff}`}
+          />
         </footer>
       </div>
     </>

--- a/src/styles/add-to-calendar.css
+++ b/src/styles/add-to-calendar.css
@@ -1,0 +1,1440 @@
+/*
+ * ++++++++++++++++++++++
+ * Add to Calendar Button
+ * ++++++++++++++++++++++
+ *
+ * Style: Default
+ *
+ * Version: 2.8.9
+ * Creator: Jens Kuerschner (https://jekuer.com)
+ * Project: https://github.com/add2cal/add-to-calendar-button
+ * License: Elastic License 2.0 (ELv2) (https://github.com/add2cal/add-to-calendar-button/blob/main/LICENSE.txt)
+ * Note:    DO NOT REMOVE THE COPYRIGHT NOTICE ABOVE!
+ * 
+ */
+
+/******************************
+ * Global colors and shadows
+ */
+
+:host {
+  width: fit-content;
+
+  --base-font-size-l: 16px;
+  --base-font-size-m: 16px;
+  --base-font-size-s: 16px;
+  --font: arial, helvetica, "Twemoji Mozilla", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "EmojiOne Color", "Android Emoji", sans-serif;
+  --accent-color: #1e90ff;
+  --wrapper-padding: 1px;
+  --buttonslist-gap: 5px;
+  --btn-background: #f5f5f5;
+  --btn-hover-background: #fff;
+  --btn-border: #d2d2d2;
+  --btn-border-radius: 6px;
+  --btn-padding-x: 1em;
+  --btn-padding-y: .65em;
+  --btn-font-weight: 600;
+  --btn-text: #333;
+  --btn-hover-text: #000;
+  --btn-shadow: rgb(0 0 0 / 10%) 0 4px 10px -2px, rgb(0 0 0 / 15%) 0 2px 2px -1px;
+  --btn-hover-shadow: rgb(0 0 0 / 25%) 0 5px 12px -2px, rgb(0 0 0 / 25%) 0 3px 5px -2px;
+  --btn-active-shadow: rgb(0 0 0 / 30%) 0 6px 13px -2px, rgb(0 0 0 / 25%) 0 4px 5px -2px;
+  --list-background: #f5f5f5;
+  --list-hover-background: #fff;
+  --list-text: #333;
+  --list-font-weight: 400;
+  --list-hover-text: #000;
+  --list-close-background: #e5e5e5;
+  --list-close-text: #777;
+  --list-border-radius: 6px;
+  --list-padding: .8em;
+  --list-shadow: rgb(0 0 0 / 20%) 0 4px 13px -2px, rgb(0 0 0 / 23%) 0 2px 4px -1px;
+  --list-modal-shadow: rgb(0 0 0 / 50%) 0 4px 30px -3px, rgb(0 0 0 / 30%) 0 2px 8px -2px;
+  --input-border-radius: 6px;
+  --input-background: #fff;
+  --status-active-text: #fff;
+  --form-error: #c5372c;
+  --form-success: #338a36;
+  --modal-text: #000;
+  --modal-text-align: center;
+  --modal-text-align-rtl: center;
+  --modal-background: #f5f5f5;
+  --modal-border-radius: 6px;
+  --modal-shadow: drop-shadow(3px 6px 25px rgb(0 0 0 / 65%));
+  --modal-btn-bar: #c6c8cd;
+  --modal-btn-background: #f5f5f5;
+  --modal-btn-secondary-background: #e2e1e6;
+  --modal-btn-hover-background: #fff;
+  --modal-btn-border: #d2d2d2;
+  --modal-btn-font-weight: 600;
+  --modal-btn-text: #2e2e2e;
+  --modal-btn-hover-text: #161616;
+  --modal-btn-secondary-text: #666567;
+  --modal-btn-shadow: rgb(0 0 0 / 10%) 0 4px 10px -2px, rgb(0 0 0 / 10%) 0 2px 3px -1px;
+  --modal-btn-hover-shadow: rgb(0 0 0 / 25%) 0 5px 13px -2px, rgb(0 0 0 / 20%) 0 3px 5px -2px;
+  --modal-headline-text-align: center;
+  --modal-headline-text-transform: none;
+  --date-btn-text: #1d1d1e;
+  --date-btn-text-secondary: #3a3a3f;
+  --date-btn-cal-day-text: #fff;
+  --date-btn-cal-month-text: #d3d2d7;
+  --date-btn-cal-background: #313132;
+  --date-btn-background: #eae9ed;
+  --date-btn-hover-background: #fff;
+  --date-btn-headline-line-clamp: 1;
+  --date-btn-shadow: rgb(0 0 0 / 10%) 0 4px 10px -2px, rgb(0 0 0 / 15%) 0 2px 3px -1px;
+  --date-btn-hover-shadow: rgb(0 0 0 / 20%) 0 5px 12px -2px, rgb(0 0 0 / 20%) 0 3px 4px -2px;
+  --checkmark-background: drop-shadow(0 0 3px #fff);
+  --overlay-background: rgb(20 20 20 / 25%);
+  --overlay-cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23777' width='16' height='16' viewBox='0 0 122.878 122.88'%3E%3Cpath d='M1.426 8.313a4.87 4.87 0 0 1 0-6.886 4.87 4.87 0 0 1 6.886 0l53.127 53.127 53.127-53.127a4.87 4.87 0 0 1 6.887 0 4.87 4.87 0 0 1 0 6.886L68.324 61.439l53.128 53.128a4.87 4.87 0 0 1-6.887 6.886L61.438 68.326 8.312 121.453a4.87 4.87 0 0 1-6.886 0 4.87 4.87 0 0 1 0-6.886l53.127-53.128L1.426 8.313h0z'/%3E%3C/svg%3E") 16 16, crosshair;
+  --icon-ms365-color: #ea3e23;
+  --icon-yahoo-color: #5f01d1;
+  --icon-filter: none;
+}
+
+/* Dark mode */
+
+/* :host-context(html.atcb-dark):host(.atcb-bodyScheme),
+:host-context(body.atcb-dark):host(.atcb-bodyScheme), */
+:host(.atcb-dark) {
+  --btn-background: #2e2e2e;
+  --btn-hover-background: #373737;
+  --btn-border: #3d3d3d;
+  --btn-text: #dedede;
+  --btn-hover-text: #f1f1f1;
+  --btn-shadow: rgb(255 255 255 / 5%) -3px -3px 30px -1px, rgb(0 0 0 / 40%) 2px 3px 10px -2px, rgb(0 0 0 / 40%) 1px 2px 3px -1px;
+  --btn-hover-shadow: rgb(0 0 0 / 90%) 2px 5px 20px -4px, rgb(0 0 0 / 50%) 1px 2px 6px -2px;
+  --btn-active-shadow: rgb(0 0 0 / 90%) 2px 5px 20px -4px, rgb(0 0 0 / 50%) 1px 2px 6px -2px;
+  --list-background: #2e2e2e;
+  --list-hover-background: #373737;
+  --list-text: #dedede;
+  --list-hover-text: #f1f1f1;
+  --list-close-background: #282828;
+  --list-shadow: rgb(0 0 0 / 60%) 0 4px 20px -2px, rgb(0 0 0 / 40%) 0 2px 4px -1px;
+  --list-modal-shadow: rgb(0 0 0 / 40%) -1px 3px 30px 2px;
+  --modal-text: #f1f1f1;
+  --modal-background: #242424;
+  --modal-shadow: drop-shadow(3px 6px 25px rgb(0 0 0 / 90%));
+  --modal-btn-bar: #38383a;
+  --modal-btn-background: #181819;
+  --modal-btn-secondary-background: #2e2d30;
+  --modal-btn-hover-background: #434246;
+  --modal-btn-border: #434246;
+  --modal-btn-text: #dbdbdb;
+  --modal-btn-hover-text: #fff;
+  --modal-btn-secondary-text: #b8b8b8;
+  --modal-btn-shadow: rgb(255 255 255 / 5%) -2px -2px 10px,rgb(0 0 0 / 40%) 3px 3px 10px -2px,rgb(0 0 0 / 40%) 1px 2px 5px -1px;
+  --input-background: #434246;
+  --status-active-text: #000;
+  --form-error: #db8680;
+  --form-success: #99de9c;
+  --date-btn-text: #ebebf0;
+  --date-btn-text-secondary: #b5b5bd;
+  --date-btn-cal-day-text: #101010;
+  --date-btn-cal-month-text: #3e3e3f;
+  --date-btn-cal-background: #c7c7cd;
+  --date-btn-background: #363636;
+  --date-btn-hover-background: #474747;
+  --date-btn-shadow: rgb(0 0 0 / 60%) 0 0 20px -2px, rgb(0 0 0 / 30%) 1px 2px 3px -1px;
+  --checkmark-background: drop-shadow(0 0 3px #0a0a0a);
+  --overlay-background: rgb(20 20 20 / 60%);
+  --icon-ms365-color: #ea3e23;
+  --icon-yahoo-color: #bebebe;
+  --icon-filter: grayscale(.2);
+}
+
+/* Size Breakpoints */
+
+/* large */
+.atcb-button-wrapper,
+.atcb-list,
+.atcb-modal-box {
+  font-size: var(--base-font-size-l);
+}
+
+/* medium */
+@media (width <= 991px) {
+  .atcb-button-wrapper,
+  .atcb-list,
+  .atcb-modal-box {
+    font-size: var(--base-font-size-m);
+  }
+}
+
+/* small */
+@media (width <= 575px) {
+  .atcb-button-wrapper,
+  .atcb-list,
+  .atcb-modal-box {
+    font-size: var(--base-font-size-s);
+  }
+}
+
+/******************************
+ * The triggering button
+ */
+
+.atcb-initialized.atcb-buttons-list {
+  gap: var(--buttonslist-gap);
+}
+
+.atcb-button-wrapper {
+  display: block;
+  padding: var(--wrapper-padding);
+  position: relative;
+}
+
+.atcb-button {
+  align-items: center;
+  background-color: var(--btn-background);
+  border: 1px solid var(--btn-border);
+  border-radius: var(--btn-border-radius);
+  box-shadow: var(--btn-shadow);
+  box-sizing: content-box;
+  color: var(--btn-text);
+  cursor: pointer;
+  display: flex;
+  font-family: var(--font);
+  font-size: 1em;
+  font-weight: var(--btn-font-weight);
+  justify-content: center;
+  line-height: 1.5em;
+  margin: .13em;
+  max-width: 300px;
+  padding: var(--btn-padding-y) var(--btn-padding-x);
+  position: relative;
+  text-align: center;
+  touch-action: manipulation;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  width: auto;
+  z-index: 1;
+}
+
+.atcb-button:not(.atcb-no-text, .atcb-modal-style, .atcb-dropoverlay, .atcb-single) {
+  min-width: calc(11.6em - 2 * var(--btn-padding-x));
+}
+
+.atcb-button.atcb-no-text {
+  display: flex;
+  place-content: center center;
+  align-items: center;
+  height: 3em;
+  width: 3em;
+  padding: 0;
+}
+
+.atcb-rtl .atcb-button {
+  direction: rtl;
+  text-align: right;
+}
+
+.atcb-button:focus-visible {
+  outline: 2px solid var(--accent-color);
+}
+
+.atcb-button:not([disabled]):focus,
+.atcb-button:not([disabled]):hover {
+  background-color: var(--btn-hover-background);
+  box-shadow: var(--btn-hover-shadow);
+  color: var(--btn-hover-text);
+  margin: 0;
+  padding: calc(var(--btn-padding-y) + .13em) calc(var(--btn-padding-x) + .13em);
+}
+
+.atcb-button.atcb-active:not(.atcb-modal-style, .atcb-dropoverlay) {
+  z-index: 15000000;
+}
+
+.atcb-button.atcb-active:not(.atcb-modal-style, .atcb-dropoverlay),
+.atcb-button.atcb-single:not([disabled]):focus,
+.atcb-button.atcb-single:not([disabled]):hover {
+  background-color: var(--btn-hover-background);
+  box-shadow: var(--btn-active-shadow);
+  color: var(--btn-hover-text);
+  margin: 0;
+  padding: calc(var(--btn-padding-y) + .13em) calc(var(--btn-padding-x) + .13em);
+}
+
+.atcb-button.atcb-no-text:focus,
+.atcb-button.atcb-no-text:hover,
+.atcb-button.atcb-no-text.atcb-active {
+  height: 3.26em;
+  width: 3.26em;
+  padding: 0 !important;
+}
+
+.atcb-button.atcb-active.atcb-dropoverlay {
+  z-index: 14000090;
+}
+
+/******************************
+ * Button Icon (also base for list icons) & Text
+ */
+
+.atcb-icon {
+  flex-grow: 0;
+  flex-shrink: 0;
+  height: 1em;
+  line-height: 1em;
+  margin-right: .8em;
+  width: 1em;
+}
+
+.atcb-rtl .atcb-icon {
+  margin-right: 0;
+  margin-left: .8em;
+}
+
+.atcb-no-text .atcb-icon {
+  margin-right: 0;
+  margin-left: 0;
+}
+
+.atcb-icon svg {
+  fill: currentcolor;
+  height: 100%;
+  width: 100%;
+}
+
+.atcb-text {
+  overflow-wrap: anywhere;
+}
+
+/******************************
+ * Options List
+ */
+
+.atcb-dropdown-anchor {
+  bottom: 4px;
+  height: 1px;
+  width: 100%;
+  opacity: 0;
+  position: absolute;
+}
+
+.atcb-list-wrapper {
+  box-sizing: border-box;
+  font-weight: var(--list-font-weight);
+  padding: 0 4px;
+  position: absolute;
+  z-index: 14000090;
+}
+
+.atcb-list-wrapper.atcb-dropoverlay {
+  z-index: 15000000;
+  max-width: max-content;
+}
+
+.atcb-list {
+  background-color: var(--list-background);
+  border-radius: 0 0 var(--list-border-radius) var(--list-border-radius);
+  box-sizing: border-box;
+  box-shadow: var(--list-shadow);
+  color: var(--list-text);
+  display: block;
+  font-family: var(--font);
+  min-width: 100%;
+  position: relative;
+  user-select: none;
+  -webkit-user-select: none;
+  width: fit-content;
+}
+
+.atcb-list-item {
+  align-items: center;
+  background-color: var(--list-background);
+  box-sizing: border-box;
+  cursor: pointer;
+  display: flex;
+  font-size: 1em;
+  line-height: 1.75em;
+  padding: var(--list-padding);
+  text-align: left;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.atcb-rtl .atcb-list-item {
+  direction: rtl;
+  text-align: right;
+}
+
+.atcb-list-item:hover {
+  background-color: var(--list-hover-background);
+  color: var(--list-hover-text);
+}
+
+.atcb-list-item:focus-visible {
+  background-color: var(--list-hover-background);
+  color: var(--accent-color);
+  outline: none;
+}
+
+.atcb-list-item:last-child {
+  border-radius: 0 0 var(--list-border-radius) var(--list-border-radius);
+}
+
+.atcb-dropup .atcb-list-item:last-child {
+  border-radius: 0;
+  padding-bottom: calc(var(--list-padding) + .45em);
+}
+
+.atcb-dropup .atcb-list-item:first-child,
+.atcb-dropoverlay .atcb-list .atcb-list-item:first-child,
+.atcb-list.atcb-modal .atcb-list-item:first-child,
+.atcb-dropup .atcb-list {
+  border-radius: var(--list-border-radius) var(--list-border-radius) 0 0;
+}
+
+.atcb-dropoverlay .atcb-list .atcb-list-item:only-child,
+.atcb-list.atcb-modal .atcb-list-item:only-child {
+  border-radius: var(--list-border-radius);
+}
+
+.atcb-list.atcb-generated-button:not(.atcb-modal) .atcb-list-item:first-child {
+  padding-top: calc(var(--list-padding) + .45em);
+}
+
+.atcb-dropup .atcb-list.atcb-generated-button:not(.atcb-modal) .atcb-list-item:first-child,
+.atcb-dropoverlay .atcb-list.atcb-generated-button:not(.atcb-modal) .atcb-list-item:first-child {
+  padding-top: var(--list-padding);
+}
+
+.atcb-dropoverlay .atcb-list,
+.atcb-list.atcb-modal {
+  border-radius: var(--list-border-radius);
+}
+
+.atcb-list.atcb-modal {
+  box-shadow: var(--list-modal-shadow);
+}
+
+.atcb-list-item .atcb-icon {
+  margin: 0 auto;
+}
+
+.atcb-list-item .atcb-icon + .atcb-text {
+  margin-left: .7em;
+  width: 100%;
+}
+
+.atcb-rtl .atcb-list-item .atcb-icon + .atcb-text {
+  margin-left: 0;
+  margin-right: .7em;
+}
+
+.atcb-list-item-close {
+  background-color: var(--list-close-background);
+}
+
+.atcb-list-item.atcb-list-item-close:not(:focus-visible) {
+  color: var(--list-close-text);
+}
+
+.atcb-list-item-close svg {
+  fill: currentcolor;
+}
+
+/******************************
+ * Modal
+ */
+
+.atcb-modal {
+  display: block;
+  margin: auto;
+  width: auto;
+  min-width: auto;
+  position: relative;
+  z-index: 14000090;
+}
+
+.atcb-modal-box {
+  filter: var(--modal-shadow);
+  color: var(--modal-text);
+  cursor: default;
+  box-sizing: border-box;  
+  font-family: var(--font);
+  line-height: 1.5em;
+  text-align: var(--modal-text-align);
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: manipulation;
+  width: 100%;
+  margin-bottom: 20px;
+  -webkit-tap-highlight-color: transparent;
+}
+
+@media (width > 575px) {
+  .atcb-modal-box {
+    width: 32em;
+  }
+}
+
+.atcb-modal-box.atcb-rtl {
+  text-align: var(--modal-text-align-rtl);
+  direction: rtl;
+  padding: 1.25em 1em 1.25em 2em;
+}
+
+/* icon */
+.atcb-modal-icon {
+  height: 2.5em;
+  width: 2.5em;
+  border-radius: 100%;
+  background-color: var(--modal-background);
+  padding: 1.75em;
+  margin: auto;
+}
+
+.atcb-modal-icon svg {
+  fill: currentcolor;
+  height: 100%;
+  width: 100%;
+}
+
+/* content */
+.atcb-modal-headline {
+  background-color: var(--modal-background);
+  border-radius: var(--modal-border-radius) var(--modal-border-radius) 0 0;
+  font-size: 1.3em;
+  font-weight: 600;
+  line-height: 1.5em;
+  padding: 1.8em 1.5em 1.3em;
+  text-transform: var(--modal-headline-text-transform);
+  text-align: var(--modal-headline-text-align);
+}
+
+.atcb-modal-icon + .atcb-modal-headline {
+  margin-top: -2.6em;
+  padding-top: 2.6em;
+}
+
+.atcb-modal-content {
+  background-color: var(--modal-background);
+  font-size: 1em;
+  padding: .3em 2em 2.2em;
+}
+
+.atcb-modal-content ul,
+.atcb-modal-content ol {
+  margin: 1em auto;
+  text-align: left;
+  width: fit-content;
+}
+
+.atcb-rtl .atcb-modal-content ul,
+.atcb-rtl .atcb-modal-content ol {
+  text-align: right;
+}
+
+.atcb-modal-content-subevents {
+  margin: auto;
+  width: fit-content;
+}
+
+.atcb-modal-icon + .atcb-modal-content {
+  border-radius: var(--modal-border-radius) var(--modal-border-radius) 0 0;
+  margin-top: -2.6em;
+  padding-top: 2.6em;
+}
+
+@media (width <= 575px) {
+  .atcb-modal-headline {
+    padding: 1.8em 1em 1em;
+  }
+  
+  .atcb-modal-content {
+    padding: .3em 1.5em 1.5em;
+  }
+
+  .atcb-modal-icon + .atcb-modal-content {
+    padding-top: 1.8em;
+  }
+}
+
+/* buttons */
+.atcb-modal-buttons {
+  background-color: var(--modal-btn-bar);
+  border-radius: 0 0 var(--modal-border-radius) var(--modal-border-radius);
+  box-sizing: border-box;
+  padding: .6em;
+  text-align: center;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  flex-flow: row-reverse wrap;
+  align-items: center;
+}
+
+button.atcb-modal-btn,
+a.atcb-modal-btn {
+  background-color: var(--modal-btn-secondary-background);
+  border: 0;
+  border-radius: var(--btn-border-radius);
+  box-shadow: var(--modal-btn-shadow);
+  color: var(--modal-btn-secondary-text);
+  cursor: pointer;
+  display: inline-block;
+  font-family: var(--font);
+  font-size: .9em;
+  font-weight: var(--modal-btn-font-weight);
+  line-height: 1em;
+  margin: .625em;
+  padding: 1em 1.25em;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  touch-action: manipulation;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+button.atcb-modal-btn.btn-small,
+a.atcb-modal-btn.btn-small {
+  padding: .6em .8em;
+}
+
+button.atcb-modal-btn.atcb-modal-btn-primary,
+a.atcb-modal-btn.atcb-modal-btn-primary {
+  background-color: var(--modal-btn-background);
+  color: var(--modal-btn-text);
+}
+
+button.atcb-modal-btn.atcb-modal-btn-border,
+a.atcb-modal-btn.atcb-modal-btn-border {
+  border: 1px solid var(--modal-btn-border);
+}
+
+button.atcb-modal-btn:focus-visible,
+a.atcb-modal-btn:focus-visible{
+  background-color: var(--modal-btn-hover-background);
+  outline: 2px solid var(--accent-color);
+}
+
+button.atcb-button:disabled,
+button.atcb-subevent-btn:disabled,
+button.atcb-modal-btn:disabled,
+a.atcb-modal-btn:disabled {
+  cursor: not-allowed;
+  opacity: .75;
+  filter: brightness(95%);
+  border-style: dashed;
+  box-shadow: none;
+}
+
+button.atcb-modal-btn:not([disabled]):hover,
+a.atcb-modal-btn:not([disabled]):hover {
+  background-color: var(--modal-btn-hover-background);
+  box-shadow: var(--modal-btn-hover-shadow);
+  color: var(--modal-btn-hover-text);
+  text-decoration: none;
+}
+
+/******************************
+ * Date Buttons
+ */
+
+.atcb-subevent-btn {
+  display: flex;
+  align-items: flex-start;
+  cursor: pointer;
+  font-family: var(--font);
+  font-size: 1em;
+  box-shadow: var(--date-btn-shadow);
+  background-color: var(--date-btn-background);
+  border: 0;
+  border-radius: 7px 4px 4px 7px;
+  padding: 0;
+  margin: 0;
+  touch-action: manipulation;
+  position: relative;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  width: 100%;
+}
+
+.atcb-subevent-btn:hover {
+  align-items: center;
+}
+
+.atcb-subevent-btn:hover,
+.atcb-subevent-btn:focus {
+  background-color: var(--date-btn-hover-background);
+  box-shadow: var(--date-btn-hover-shadow);  
+}
+
+.atcb-subevent-btn:focus-visible {
+  outline: 2px solid var(--accent-color);
+}
+
+.atcb-subevent-btn + .atcb-subevent-btn {
+  margin-top: 30px;
+}
+
+.atcb-date-btn-left {
+  border-radius: 4px 0 0 4px;
+  align-self: stretch;
+  background-color: var(--date-btn-cal-background);
+  color: var(--date-btn-hover-background);
+  padding: .7em .8em .8em;
+  width: 2.7em;
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+}
+
+.atcb-rtl .atcb-date-btn-left {
+  border-radius: 0 4px 4px 0;
+}
+
+.atcb-subevent-btn:hover .atcb-date-btn-left {
+  opacity: .8;
+}
+
+.atcb-date-btn-day {
+  color: var(--date-btn-cal-day-text);
+  font-weight: 400;
+  font-size: 2em;
+  word-break: keep-all;
+  padding-bottom: .1em;
+}
+
+.atcb-initialized[lang="zh"] .atcb-date-btn-day,
+.atcb-initialized[lang="ja"] .atcb-date-btn-day,
+.atcb-initialized[lang="ko"] .atcb-date-btn-day {
+  font-size: 1.3em;
+}
+
+.atcb-date-btn-month {
+  color: var(--date-btn-cal-month-text);
+  font-weight: 600;
+  font-size: 1em;
+}
+
+.atcb-date-btn-right {
+  position: relative;
+  color: var(--date-btn-text);
+  min-width: 13.5em;
+  overflow-wrap: anywhere;
+}
+
+.atcb-subevent-btn .atcb-date-btn-right {
+  width: 100%;
+}
+
+.atcb-date-btn-details {
+  opacity: 1;
+  padding: .7em .8em;
+  text-align: left;
+}
+
+.atcb-rtl .atcb-date-btn-details {
+  text-align: right;
+}
+
+.atcb-date-btn-hover {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  opacity: 0;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 1em;
+  padding: .4em .7em;
+  box-sizing: border-box;
+}
+
+.atcb-subevent-btn:hover .atcb-date-btn-details {
+  opacity: 0;
+}
+
+.atcb-subevent-btn:hover .atcb-date-btn-hover {
+  opacity: 1;
+}
+
+.atcb-date-btn-headline {
+  font-weight: 600;
+  font-size: .9em;
+  margin-bottom: .5em;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: var(--date-btn-headline-line-clamp);
+  line-clamp: var(--date-btn-headline-line-clamp);
+}
+
+.atcb-date-btn-content {
+  display: flex;
+  align-items: flex-start;
+  font-size: .8em;
+  color: var(--date-btn-text-secondary);
+}
+
+.atcb-date-btn-content.atcb-date-btn-cancelled {
+  color: var(--form-error);
+  font-weight: bold;
+}
+
+.atcb-date-btn-content-location {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  line-clamp: 1;
+  word-break: break-all;
+}
+
+.atcb-date-btn-content-icon {
+  display: inline-block;
+  height: 0.8em;
+  margin-right: .4em;
+  margin-left: .0;
+  width: 0.9em;
+  flex-shrink: 0;
+}
+
+.atcb-rtl .atcb-date-btn-content-icon {
+  margin-right: 0;
+  margin-left: .4em;
+}
+
+.atcb-initialized[lang="zh"] .atcb-date-btn-content:not(.atcb-date-btn-content-location) .atcb-date-btn-content-icon,
+.atcb-initialized[lang="ja"] .atcb-date-btn-content:not(.atcb-date-btn-content-location) .atcb-date-btn-content-icon,
+.atcb-initialized[lang="ko"] .atcb-date-btn-content:not(.atcb-date-btn-content-location) .atcb-date-btn-content-icon {
+  margin-top: .15em;
+}
+
+.atcb-date-btn-content-icon svg {
+  height: 100%;
+  fill: currentcolor;
+  width: 100%
+}
+
+.atcb-date-btn-content + .atcb-date-btn-content {
+  margin-top: .3em;
+}
+
+.atcb-date-btn-content-text span:not(.atcb-icon-ical) {
+  padding-right: .3em;
+  display: inline-block;
+}
+
+/******************************
+ * Checkmark Overlay
+ */
+
+.atcb-checkmark {
+  display: none;
+}
+
+.atcb-saved .atcb-checkmark {
+  box-sizing: content-box;
+  color: var(--btn-text);
+  display: block;
+  position: absolute;
+  top: -.9em;
+  right: -.5em;
+  padding: .5em;
+  border-radius: 100%;
+  height: 1.2em;
+}
+
+.atcb-button.atcb-active:not(.atcb-modal-style, .atcb-dropoverlay) .atcb-checkmark,
+.atcb-button.atcb-single:focus .atcb-checkmark,
+.atcb-button.atcb-single:hover .atcb-checkmark {
+  top: -.77em;
+  right: -.37em;
+}
+
+.atcb-checkmark svg {
+  height: 100%;
+  filter: var(--checkmark-background);
+  width: auto;
+}
+
+/******************************
+ * Background Overlay
+ */
+
+#atcb-bgoverlay {
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  background-color: var(--overlay-background);
+  border: 0;
+  box-sizing: border-box;
+  display: flex;
+  
+  /* could become simply 100dvh in the future - with regular padding then */
+  height: calc(100vh + 100px);
+  inset-inline: 0;
+  left: 0;
+  right: 0;
+  top: 0;
+  min-height: 100%;
+  min-width: 100%;
+  overflow-y: auto;
+  padding: 20px 20px 130px;
+  position: fixed;
+  width: 100vw;
+  z-index: 14000000;
+}
+
+#atcb-bgoverlay:not(dialog) {
+  animation: atcb-bgoverlay-animate 0.2s ease 0s 1 normal forwards;
+  opacity: 0;
+}
+
+#atcb-bgoverlay.atcb-no-bg {
+  animation: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  opacity: 1;
+  background-color: transparent;
+}
+
+@keyframes atcb-bgoverlay-animate {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+#atcb-bgoverlay.atcb-click:hover {
+  cursor: var(--overlay-cursor);
+}
+
+/******************************
+ * Icon specifics
+ */
+
+.atcb-icon.atcb-icon-ms365, .atcb-icon-outlookcom {
+  padding-bottom: .05em;
+}
+
+.atcb-icon.atcb-icon-apple, .atcb-icon.atcb-icon-ical {
+  padding-bottom: .15em;
+}
+
+.atcb-icon.atcb-icon-trigger {
+  padding-bottom: .15em;
+}
+
+.atcb-icon.atcb-icon-rsvp {
+  height: 1.5em;
+  width: 1.5em;
+}
+
+.atcb-icon.atcb-icon-apple svg {
+  fill: currentcolor;
+}
+
+.atcb-icon.atcb-icon-ical svg {
+  fill: currentcolor;
+}
+
+.atcb-icon.atcb-icon-ms365 svg {
+  fill: var(--icon-ms365-color);
+}
+
+.atcb-icon.atcb-icon-yahoo svg {
+  fill: var(--icon-yahoo-color);
+}
+
+.atcb-icon.atcb-icon-google svg,
+.atcb-icon.atcb-icon-msteams svg,
+.atcb-icon.atcb-icon-outlookcom svg {
+  filter: var(--icon-filter);
+}
+
+/******************************
+ * PRO Features
+ */
+
+.rsvp-inline-wrapper {
+  filter: none;
+  min-width: 100%;
+  margin-bottom: 0;
+}
+
+.atcb-modal-content.no-headline {
+  border-radius: var(--modal-border-radius) var(--modal-border-radius) 0 0;
+  padding-top: 1.8em;
+}
+
+.rsvp-inline-wrapper .atcb-modal-headline,
+.rsvp-inline-wrapper .atcb-modal-content,
+.rsvp-inline-wrapper.atcb-modal-box {
+  background-color: transparent;
+  border-radius: 0;
+  box-sizing: border-box;
+  padding: 0;
+  width: 100%;
+}
+
+.rsvp-inline-wrapper .atcb-modal-headline {
+  padding-bottom: 1.5em;
+}
+
+.pro {
+  text-align: center;
+}
+
+.pro a:not(.atcb-modal-btn),
+.pro a:not(.atcb-modal-btn):visited,
+.pro a:not(.atcb-modal-btn):active {
+  color: var(--modal-btn-text);
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-decoration-color: var(--accent-color);
+}
+
+.pro a:not(.atcb-modal-btn):hover {
+  color: var(--accent-color);
+  text-decoration: none;
+}
+
+.pro .pro-share-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.pro #rsvp-atcb {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .4em;
+  justify-content: center;
+}
+
+.pro-form {
+  text-align: left;
+}
+
+.pro-form:not(.no-intro) {
+  border-top: 1px solid var(--modal-btn-border);
+  margin-top: 1.5em;
+  padding-top: 1.5em;
+}
+
+.pro-form.no-intro:not(.no-headline) {
+  padding-top: .5em;
+}
+
+.pro-field + .pro-field {
+  padding-top: 1.3em;
+}
+
+.pro-field-type-label + .pro-field-type-radio {
+  padding-top: 0;
+}
+
+.pro-field-type-checkbox,
+.pro-field-type-radio div {
+  align-items: center;
+  display: flex;
+}
+
+.pro-field-type-checkbox input,
+.pro-field-type-radio input {
+  cursor: pointer;
+}
+
+.pro-field label {
+  display: block;
+  font-size: .9em;
+  opacity: .7;
+}
+
+.pro-field-type-checkbox label,
+.pro-field-type-radio label {
+  cursor: pointer;
+  opacity: .8;
+  padding-left: .3em;
+}
+
+.pro-field input[type="text"],
+.pro-field input[type="email"],
+.pro-field input[type="number"] {
+  background-color: var(--input-background);
+  border: 1px solid var(--modal-btn-border);
+  border-radius: var(--input-border-radius);
+  box-sizing: border-box;
+  caret-color: var(--accent-color);
+  color: var(--modal-text);
+  font-size: .9em;
+  opacity: .8;
+  padding: .7em;
+  transition: all .1s ease-in-out;
+  width: 100%;
+}
+
+.pro-field input[type="checkbox"],
+.pro-field input[type="radio"] {
+  accent-color: var(--accent-color);
+  height: 1.2rem;
+  opacity: .8;
+  transition: all .1s ease-in-out;
+  width: 1.2em;
+}
+
+.pro-field input:disabled,
+.pro-field input:disabled + label {
+  cursor: not-allowed;
+  opacity: .75;
+  filter: brightness(95%);
+}
+
+.pro-field input:not([disabled]):hover {
+  opacity: 1;
+}
+
+.pro-field input[type="text"]:focus,
+.pro-field input[type="email"]:focus,
+.pro-field input[type="number"]:focus {
+  border-color: var(--accent-color);
+  outline: 1px solid var(--accent-color);
+}
+
+.pro-field input[type="checkbox"]:focus,
+.pro-field input[type="radio"]:focus {
+  outline-color: var(--accent-color);
+  outline-width: 2px;
+}
+
+#submit-error {
+  color: var(--form-error);
+  display: none;
+  font-weight: bold;
+  padding-top: 1.5em;
+  text-align: center;
+}
+
+.pro-form.form-error #submit-error {
+  display: block;
+}
+
+.pro-field input.error {
+  accent-color: var(--form-error);
+  border: 2px solid var(--form-error);
+}
+
+.pro-field input.error + label,
+.pro-field:has(input.error) label {
+  color: var(--form-error);
+  opacity: 1;
+}
+
+#rsvp-status-group {
+  border-bottom: 1px solid var(--modal-btn-border);
+  font-weight: bold;
+  margin-bottom: 1.5em;
+  padding-bottom: 2em;
+  text-align: center;
+}
+
+#rsvp-status-group .pro-field {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3%;
+  justify-content: center;
+  margin-top: 1em;
+}
+
+@media (width <= 575px) {
+  #rsvp-status-group .pro-field {
+    flex-direction: column;
+    gap: 1.2em;
+  }
+
+  #rsvp-status-group .pro-field div {
+    width: 80%;
+  }
+}
+
+#rsvp-status-group .pro-field div {
+  min-width: 28%;
+  position: relative;
+}
+
+#rsvp-status-group input {
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  margin: 0;
+  cursor: pointer;
+}
+
+#rsvp-status-group label {
+  align-items: center;
+  border: 1px solid var(--modal-btn-text);
+  border-radius: var(--input-border-radius);
+  box-shadow: var(--btn-shadow);
+  color: var(--modal-btn-text);
+  display: flex;
+  flex-direction: column;
+  font-weight: bold;
+  text-transform: uppercase;
+  justify-content: center;
+  opacity: .6;
+  padding: .8em;
+  transition: all .1s ease-in-out;
+  width: 100%;
+}
+
+#rsvp-status-group label.status-confirmed {
+  border-color: var(--form-success);
+  color: var(--form-success);
+}
+
+#rsvp-status-group label.status-declined {
+  border-color: var(--form-error);
+  color: var(--form-error);
+}
+
+#rsvp-status-group input:checked + label {
+  background-color: var(--modal-text);
+  box-shadow: var(--btn-hover-shadow);
+  color: var(--status-active-text);
+  opacity: 1;
+  transform: scale(1.08);
+}
+
+#rsvp-status-group input:focus-visible + label {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+}
+
+#rsvp-status-group input:not([disabled]) + label:hover,
+#rsvp-status-group input:not([disabled]):hover + label {
+  box-shadow: var(--btn-hover-shadow);
+  opacity: 1;
+  transform: scale(1.08);
+}
+
+#rsvp-status-group input:checked + label.status-confirmed {
+  background-color: var(--form-success);
+}
+
+#rsvp-status-group input:checked + label.status-declined {
+  background-color: var(--form-error);
+}
+
+#ty-success-msg,
+#rsvp-success-msg,
+#rsvp-success-msg-email,
+#rsvp-success-msg-doi,
+#rsvp-success-msg-demo {
+  display: none;
+  font-weight: bold;
+  line-height: 1.6em;
+  padding-top: 0.5em;
+  text-align: center;
+}
+
+#ty-success-msg,
+#rsvp-success-msg,
+#rsvp-success-msg-demo {
+  padding: 1.5em 0;
+}
+
+#rsvp-success-msg-email,
+#rsvp-success-msg-demo {
+  color: var(--form-success);
+}
+
+#rsvp-success-msg-doi {
+  color: var(--form-error);
+  padding-top: 1em;
+  font-size: .8em;
+}
+
+#pro-form-submit {
+  display: block;
+  margin: auto;
+  min-width: 150px;
+}
+
+.pro-form-fine {
+  font-size: .8em;
+  margin: .5em auto 1em;
+  opacity: .5;
+  text-align: center;
+}
+
+.pro-form.form-error .pro-form-fine {
+  opacity: 0;
+}
+
+.pro-waiting {
+  background-color: var(--modal-btn-background);
+  border: 1px solid var(--modal-btn-border);
+  border-radius: var(--btn-border-radius);
+  box-sizing: border-box;
+  color: var(--modal-btn-text);
+  cursor: wait;
+  display: none;
+  line-height: .5em;
+  margin: auto;
+  min-width: 150px;
+  padding: .5em 1.25em 1.2em;
+  text-align: center;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  width: fit-content;
+}
+
+@media (width > 575px) {
+  #pro-form-submit,
+  .pro-waiting {
+    min-width: 200px;
+  }
+}
+
+.pro-waiting span:not(.atcb-icon-ical) {
+  animation-name: blink;
+  animation-duration: 1s;
+  animation-iteration-count: infinite;
+  animation-fill-mode: both;
+  font-size: 2.5em;
+}
+
+.pro-field label span:not(.atcb-icon-ical) {
+  color: var(--form-error);
+  font-weight: bold;
+  padding-left: 2px;
+}
+
+.pro-waiting span:not(.atcb-icon-ical):nth-child(2) {
+  animation-delay: .15s;
+}
+
+.pro-waiting span:not(.atcb-icon-ical):nth-child(3) {
+  animation-delay: .3s;
+}
+
+@keyframes blink {
+  0% {
+    opacity: .2;
+  }
+
+  20% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: .2;
+  }
+}
+
+.pro #rsvp-sent-content {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5em;
+}
+
+/* overrides */
+#rsvp-status-group span {
+  color: inherit;
+}
+
+.atcb-modal-content .pro p:not(.pro-form-fine) {
+  margin: 0;
+}
+
+.atcb-modal-content .pro p.pro-pt {
+  margin-top: 1.5em;
+}
+
+.atcb-modal-content .pro .pro-field p {
+  font-size: .9em;
+}
+
+.pro .btn-flex {
+  align-items: center;
+  display: flex;
+}
+
+.pro .atcb-modal-btn svg {
+  fill: none;
+  height: 1.5em;
+  margin-right: .5em;
+  stroke: currentcolor;
+  width: auto;
+}
+
+/******************************
+ * PRO Reference
+ */
+
+#atcb-reference {
+  box-sizing: border-box;
+  filter: drop-shadow(0 0 3px rgb(255 255 255 / 80%));
+  height: auto;
+  padding: 8px 0;
+  text-align: center;
+  transform: translate3d(0, 0, 0);
+  width: 100%;
+  z-index: 15000000;
+}
+
+#atcb-reference.fixed-ref {
+  position: fixed;
+  bottom: 10px;
+  right: 40px;
+  width: auto;
+}
+
+#atcb-reference.atcb-dropup {
+  position: absolute;
+  margin-top: -1px;
+}
+
+.atcb-modal-host-initialized #atcb-reference.atcb-dropup {
+  text-align: left;
+}
+
+/* :host-context(html.atcb-dark):host(.atcb-bodyScheme) #atcb-reference,
+:host-context(body.atcb-dark):host(.atcb-bodyScheme) #atcb-reference, */
+:host(.atcb-dark) #atcb-reference {
+  filter: drop-shadow(0 0 5px #000);
+}
+
+#atcb-reference a,
+#atcb-reference a:active,
+#atcb-reference a:visited {
+  opacity: .4;
+  width: 150px;
+  max-width: 100%;
+  margin: auto;
+  display: inline-block;
+  text-decoration: none;
+}
+
+#atcb-reference.fixed-ref a {
+  opacity: .6;
+}
+
+#atcb-reference a:hover {
+  opacity: .9;
+  text-decoration: none;
+}
+
+#atcb-reference svg {
+  fill: var(--list-text);
+}


### PR DESCRIPTION
## Summary
- surface Add To Calendar button next to the registry CTA on the main page
- repeat the Add To Calendar button in the footer below the About link
- add the required Add to Calendar styles globally

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6862cca15810832c871ac0f3fb528557