### PR TITLE
Add hero and footer calendar buttons

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,10 +7,10 @@ import dynamic from 'next/dynamic'
 import { motion } from 'framer-motion'
 import { ChevronDown } from 'lucide-react'
 import LoadingScreen from '@/components/LoadingScreen'
+import AddToCalendar, { CalendarEvent } from '@/components/AddToCalendar'
 
 /* ----------------------------- Dynamic imports ---------------------------- */
 const WeddingIntro = dynamic<{ onFinish?: () => void }>(() => import('@/components/WeddingIntro'), { ssr: false, loading: () => <LoadingScreen /> })
-const AddToCalendarButtonClient = dynamic(() => import('add-to-calendar-button-react').then((m) => m.AddToCalendarButton), { ssr: false })
 
 /* -------------------------------------------------------------------------- */
 /*                                  Palette                                   */
@@ -42,6 +42,17 @@ const jsonLd = {
   },
   description: 'A joyful celebration of love uniting Abbigayle & Frederick in historic Plummer House gardens.',
   organizer: { '@type': 'Person', name: 'Frederick de', url: '*   https://github.com/fderuiter/wedding_website' },
+}
+
+const calendarEvent: CalendarEvent = {
+  name: jsonLd.name,
+  startDate: '2025-10-10',
+  startTime: '16:00',
+  endDate: '2025-10-10',
+  endTime: '22:00',
+  timeZone: 'America/Chicago',
+  location: 'Plummer House, 1091 Plummer Ln SW, Rochester, MN',
+  description: jsonLd.description,
 }
 
 const fadeUp = { hidden: { opacity: 0, y: 40 }, visible: (i: number) => ({ opacity: 1, y: 0, transition: { delay: 0.15 * i, duration: 0.8 } }) }
@@ -78,21 +89,7 @@ export default function HomePage() {
             <a href="/registry" className="inline-block rounded-full border border-rose-600 px-8 py-3 font-medium text-rose-700 transition-colors hover:bg-rose-50">
               Registry
             </a>
-            <AddToCalendarButtonClient
-              name={jsonLd.name}
-              startDate="2025-10-10"
-              startTime="16:00"
-              endDate="2025-10-10"
-              endTime="22:00"
-              timeZone="America/Chicago"
-              location="Plummer House, 1091 Plummer Ln SW, Rochester, MN"
-              description={jsonLd.description}
-              options={['Google', 'Apple', 'iCal', 'Outlook.com', 'Yahoo']}
-              buttonStyle="round"
-              label="Add to Calendar"
-              size="2"
-              inline
-            />
+            <AddToCalendar event={calendarEvent} />
           </motion.div>
         </section>
 
@@ -131,21 +128,7 @@ export default function HomePage() {
             </div>
           </div>
           <div className="mt-14 flex justify-center">
-            <AddToCalendarButtonClient
-              name={jsonLd.name}
-              startDate="2025-10-10"
-              startTime="16:00"
-              endDate="2025-10-10"
-              endTime="22:00"
-              timeZone="America/Chicago"
-              location="Plummer House, 1091 Plummer Ln SW, Rochester, MN"
-              description={jsonLd.description}
-              options={['Google', 'Apple', 'iCal', 'Outlook.com', 'Yahoo']}
-              buttonStyle="round"
-              label="Add to Calendar"
-              size="2"
-              inline
-            />
+            <AddToCalendar event={calendarEvent} />
           </div>
         </motion.section>
 
@@ -201,21 +184,7 @@ export default function HomePage() {
         <footer className="flex flex-col items-center gap-4 px-4 pb-10 text-sm text-gray-500">
           <p>© {new Date().getFullYear()} Abbigayle & Frederick • Designed with ❤️ in Minnesota</p>
           <a href="/project-info" className="text-rose-600 hover:underline">About this site</a>
-          <AddToCalendarButtonClient
-            name={jsonLd.name}
-            startDate="2025-10-10"
-            startTime="16:00"
-            endDate="2025-10-10"
-            endTime="22:00"
-            timeZone="America/Chicago"
-            location="Plummer House, 1091 Plummer Ln SW, Rochester, MN"
-            description={jsonLd.description}
-            options={['Google', 'Apple', 'iCal', 'Outlook.com', 'Yahoo']}
-            buttonStyle="round"
-            label="Add to Calendar"
-            size="2"
-            inline
-          />
+          <AddToCalendar event={calendarEvent} />
         </footer>
       </div>
     </>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,13 +16,6 @@ const AddToCalendarButtonClient = dynamic(() => import('add-to-calendar-button-r
 /*                                  Palette                                   */
 /* -------------------------------------------------------------------------- */
 // Elegant neutrals + rose accent
-const COLORS = {
-  text: '#374151', // gray‑700
-  heading: '#be123c', // rose‑700
-  accentFrom: '#be123c', // rose‑700
-  accentTo: '#f59e0b', // amber‑500
-  bg: '#fffdfc',
-}
 
 /* -------------------------------------------------------------------------- */
 /*                                  JSON‑LD                                   */
@@ -63,7 +56,7 @@ export default function HomePage() {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
 
       {/* Global wrapper provides consistent background */}
-      <div className="min-h-screen bg-[${COLORS.bg}] text-[${COLORS.text}] selection:bg-rose-100 selection:text-rose-900">
+      <div className="min-h-screen bg-[#fffdfc] text-[#374151] selection:bg-rose-100 selection:text-rose-900">
         {/* -------------------------------------------------------------- */}
         {/* Hero                                                          */}
         {/* -------------------------------------------------------------- */}
@@ -85,6 +78,21 @@ export default function HomePage() {
             <a href="/registry" className="inline-block rounded-full border border-rose-600 px-8 py-3 font-medium text-rose-700 transition-colors hover:bg-rose-50">
               Registry
             </a>
+            <AddToCalendarButtonClient
+              name={jsonLd.name}
+              startDate="2025-10-10"
+              startTime="16:00"
+              endDate="2025-10-10"
+              endTime="22:00"
+              timeZone="America/Chicago"
+              location="Plummer House, 1091 Plummer Ln SW, Rochester, MN"
+              description={jsonLd.description}
+              options={['Google', 'Apple', 'iCal', 'Outlook.com', 'Yahoo']}
+              buttonStyle="round"
+              label="Add to Calendar"
+              size="2"
+              inline
+            />
           </motion.div>
         </section>
 
@@ -123,7 +131,21 @@ export default function HomePage() {
             </div>
           </div>
           <div className="mt-14 flex justify-center">
-            <AddToCalendarButtonClient name={jsonLd.name} startDate="2025-10-10" startTime="16:00" endDate="2025-10-10" endTime="22:00" timeZone="America/Chicago" location="Plummer House, 1091 Plummer Ln SW, Rochester, MN" description={jsonLd.description} options={['Google', 'Apple', 'iCal', 'Outlook.com', 'Yahoo']} buttonStyle="round" label="Add to Calendar" size="2" inline customCss={`:root{--btn-background:linear-gradient(135deg,${COLORS.accentFrom},${COLORS.accentTo});--btn-text:#fff}`} />
+            <AddToCalendarButtonClient
+              name={jsonLd.name}
+              startDate="2025-10-10"
+              startTime="16:00"
+              endDate="2025-10-10"
+              endTime="22:00"
+              timeZone="America/Chicago"
+              location="Plummer House, 1091 Plummer Ln SW, Rochester, MN"
+              description={jsonLd.description}
+              options={['Google', 'Apple', 'iCal', 'Outlook.com', 'Yahoo']}
+              buttonStyle="round"
+              label="Add to Calendar"
+              size="2"
+              inline
+            />
           </div>
         </motion.section>
 
@@ -179,6 +201,21 @@ export default function HomePage() {
         <footer className="flex flex-col items-center gap-4 px-4 pb-10 text-sm text-gray-500">
           <p>© {new Date().getFullYear()} Abbigayle & Frederick • Designed with ❤️ in Minnesota</p>
           <a href="/project-info" className="text-rose-600 hover:underline">About this site</a>
+          <AddToCalendarButtonClient
+            name={jsonLd.name}
+            startDate="2025-10-10"
+            startTime="16:00"
+            endDate="2025-10-10"
+            endTime="22:00"
+            timeZone="America/Chicago"
+            location="Plummer House, 1091 Plummer Ln SW, Rochester, MN"
+            description={jsonLd.description}
+            options={['Google', 'Apple', 'iCal', 'Outlook.com', 'Yahoo']}
+            buttonStyle="round"
+            label="Add to Calendar"
+            size="2"
+            inline
+          />
         </footer>
       </div>
     </>

--- a/src/components/AddToCalendar.tsx
+++ b/src/components/AddToCalendar.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import 'add-to-calendar-button/assets/css/atcb.css'
+
 import dynamic from 'next/dynamic'
 import React from 'react'
 

--- a/src/components/AddToCalendar.tsx
+++ b/src/components/AddToCalendar.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import React from 'react'
+
+const AddToCalendarButton = dynamic(
+  () => import('add-to-calendar-button-react').then((m) => m.AddToCalendarButton),
+  { ssr: false }
+)
+
+export interface CalendarEvent {
+  name: string
+  startDate: string
+  startTime: string
+  endDate: string
+  endTime: string
+  timeZone: string
+  location: string
+  description: string
+}
+
+interface AddToCalendarProps {
+  event: CalendarEvent
+  className?: string
+}
+
+export default function AddToCalendar({ event, className }: AddToCalendarProps) {
+  const style =
+    '--btn-background:linear-gradient(to right,#be123c,#f59e0b);' +
+    '--btn-hover-background:linear-gradient(to right,#f59e0b,#be123c);' +
+    '--btn-text:#fff;' +
+    '--btn-hover-text:#fff;' +
+    '--btn-border-radius:9999px;' +
+    '--btn-shadow:rgba(0,0,0,0.1) 0 4px 10px -2px;' +
+    '--btn-hover-shadow:rgba(0,0,0,0.2) 0 5px 12px -2px;'
+
+  return (
+    <div className={className}>
+      <AddToCalendarButton
+        name={event.name}
+        startDate={event.startDate}
+        startTime={event.startTime}
+        endDate={event.endDate}
+        endTime={event.endTime}
+        timeZone={event.timeZone}
+        location={event.location}
+        description={event.description}
+        options={['Google', 'Apple', 'iCal', 'Outlook.com', 'Yahoo']}
+        buttonStyle="round"
+        styleLight={style}
+        label="Add to Calendar"
+        size="2"
+        inline
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- surface Add To Calendar button next to the registry CTA on the main page
- repeat the Add To Calendar button in the footer below the About link
- remove incorrect custom CSS usage so buttons render

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6862cca15810832c871ac0f3fb528557