### PR TITLE
Fix AddToCalendar button label

### DIFF
--- a/src/components/AddToCalendar.tsx
+++ b/src/components/AddToCalendar.tsx
@@ -46,7 +46,7 @@ export default function AddToCalendar({ event, className }: AddToCalendarProps) 
         location={event.location}
         description={event.description}
         options={['Google', 'Apple', 'iCal', 'Outlook.com', 'Yahoo']}
-        buttonStyle="round"
+        buttonStyle="default"
         styleLight={style}
         label="Add to Calendar"
         size="2"


### PR DESCRIPTION
## Summary
- ensure AddToCalendar shows label text by using default button style

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862e17faee8832cb777b4cc01cb31ca