### PR TITLE
Enable automatic dark mode support

### DIFF
--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -32,14 +32,14 @@ export default function AdminDashboardPage() {
 
   if (loading) return (
     // Updated background
-    <main className="min-h-screen flex items-center justify-center bg-[#fffdfc]">
+    <main className="min-h-screen flex items-center justify-center bg-[var(--color-background)] text-[var(--color-foreground)]">
       <h1 className="text-3xl font-bold mb-4 text-rose-700">Admin Dashboard</h1>
       <p className="text-lg text-gray-500">Loading items...</p>
     </main>
   );
   if (error) return (
     // Updated background
-    <main className="min-h-screen flex items-center justify-center bg-[#fffdfc]">
+    <main className="min-h-screen flex items-center justify-center bg-[var(--color-background)] text-[var(--color-foreground)]">
       <h1 className="text-3xl font-bold mb-4 text-rose-700">Admin Dashboard</h1>
       <p className="text-red-500 text-lg">Error: {error}</p>
     </main>
@@ -47,7 +47,7 @@ export default function AdminDashboardPage() {
 
   return (
     // Updated background, removed dark mode
-    <main className="min-h-screen bg-[#fffdfc] py-10 px-2 sm:px-6">
+    <main className="min-h-screen bg-[var(--color-background)] text-[var(--color-foreground)] py-10 px-2 sm:px-6">
       <div className="max-w-5xl mx-auto">
         {/* Updated heading color */}
         <h1 className="text-4xl font-extrabold mb-8 text-center text-rose-700 tracking-tight drop-shadow-lg">Admin Dashboard</h1>

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -33,7 +33,7 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-[#fffdfc] px-2">
+    <div className="min-h-screen flex items-center justify-center bg-[var(--color-background)] text-[var(--color-foreground)] px-2">
       <form onSubmit={handleLogin} className="w-full max-w-md bg-white rounded-2xl shadow-2xl p-8 sm:p-10 flex flex-col gap-6 border border-rose-100">
         <h1 className="text-3xl font-extrabold text-center text-rose-700 mb-2 tracking-tight">Admin Login</h1>
         {error && <p className="text-red-500 text-sm text-center -mt-2">{error}</p>}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,6 +15,21 @@
   --font-mono: var(--font-geist-mono);
 }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #1a1a1a;
+    --foreground: #e5e5e5;
+    --color-background: var(--background);
+    --color-foreground: var(--foreground);
+    --color-primary: #f43f5e; /* rose-500 */
+    --color-secondary: #fbbf24; /* amber-400 */
+    --color-accent-from: #f43f5e;
+    --color-accent-to: #fbbf24;
+    --color-text-on-primary: #fff;
+    --color-text-on-secondary: #1a1a1a;
+  }
+}
+
 body {
   background: var(--background);
   color: var(--foreground);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -68,7 +68,7 @@ export default function RootLayout({
         <link rel="icon" href="/assets/favicon.png" type="image/png" />
       </Head>
       {/* Apply base theme colors directly to body */}
-      <body className={`${geist.variable} bg-[#fffdfc] text-[#374151] selection:bg-rose-100 selection:text-rose-900`}>
+      <body className={`${geist.variable} selection:bg-rose-100 selection:text-rose-900`}>
         <QueryClientProvider client={queryClient}>
           {loading && <LoadingScreen />}
           {/* Admin Indicator and Logout Button - Restyled */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -67,7 +67,7 @@ export default function HomePage() {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
 
       {/* Global wrapper provides consistent background */}
-      <div className="min-h-screen bg-[#fffdfc] text-[#374151] selection:bg-rose-100 selection:text-rose-900">
+      <div className="min-h-screen bg-[var(--color-background)] text-[var(--color-foreground)] selection:bg-rose-100 selection:text-rose-900">
         {/* -------------------------------------------------------------- */}
         {/* Hero                                                          */}
         {/* -------------------------------------------------------------- */}

--- a/src/app/project-info/page.tsx
+++ b/src/app/project-info/page.tsx
@@ -29,7 +29,7 @@ const sectionVariants = {
 
 const ProjectInfo = () => {
   return (
-    <div className="min-h-screen bg-[#fffdfc] text-[#374151] selection:bg-rose-100 selection:text-rose-900 pb-24">
+    <div className="min-h-screen bg-[var(--color-background)] text-[var(--color-foreground)] selection:bg-rose-100 selection:text-rose-900 pb-24">
       {/* Hero Section */}
       <motion.div
         className="max-w-3xl mx-auto text-center py-20 px-4"

--- a/src/app/registry/page.tsx
+++ b/src/app/registry/page.tsx
@@ -182,7 +182,7 @@ export default function RegistryPage() {
 
   return (
     // Updated background to match main page
-    <div className="min-h-screen bg-[#fffdfc] text-[#374151] selection:bg-rose-100 selection:text-rose-900 pb-32 px-2 sm:px-4">
+    <div className="min-h-screen bg-[var(--color-background)] text-[var(--color-foreground)] selection:bg-rose-100 selection:text-rose-900 pb-32 px-2 sm:px-4">
       <motion.h1
         // Updated heading color to rose-700
         className="text-5xl font-extrabold text-center mb-12 pt-12 text-rose-700 tracking-tight drop-shadow-lg"

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -100,7 +100,7 @@ const Modal: React.FC<ModalProps> = ({ item, onClose, onContribute }) => {
     // Updated backdrop
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-60 z-50 p-4" role="dialog" aria-modal="true" ref={modalRef}>
       {/* Updated modal background and text color, removed dark mode */}
-      <div className="bg-white rounded-lg shadow-xl max-w-xl w-full p-6 relative max-h-[90vh] overflow-y-auto text-[#374151]">
+      <div className="bg-white rounded-lg shadow-xl max-w-xl w-full p-6 relative max-h-[90vh] overflow-y-auto text-[var(--color-foreground)]">
         {/* Close Button - Adjusted color */}
         <button
           className="absolute top-3 right-3 text-gray-500 hover:text-rose-600 text-2xl font-bold"
@@ -167,7 +167,7 @@ const Modal: React.FC<ModalProps> = ({ item, onClose, onContribute }) => {
               type="text"
               placeholder="Your Name"
               // Updated input styles
-              className="border border-gray-300 p-2 rounded w-full mb-3 focus:ring-2 focus:ring-rose-400 outline-none bg-white text-[#374151]"
+              className="border border-gray-300 p-2 rounded w-full mb-3 focus:ring-2 focus:ring-rose-400 outline-none bg-white text-[var(--color-foreground)]"
               value={contributorName}
               onChange={(e) => setContributorName(e.target.value)}
               disabled={isSubmitting}
@@ -177,7 +177,7 @@ const Modal: React.FC<ModalProps> = ({ item, onClose, onContribute }) => {
                 type="number"
                 placeholder={`Contribution Amount (up to $${remainingAmount.toFixed(2)})`}
                 // Updated input styles
-                className="border border-gray-300 p-2 rounded w-full mb-3 focus:ring-2 focus:ring-rose-400 outline-none bg-white text-[#374151]"
+                className="border border-gray-300 p-2 rounded w-full mb-3 focus:ring-2 focus:ring-rose-400 outline-none bg-white text-[var(--color-foreground)]"
                 value={amount}
                 onChange={(e) => setAmount(e.target.value)}
                 min="0.01"

--- a/src/components/RegistryCard.tsx
+++ b/src/components/RegistryCard.tsx
@@ -16,7 +16,7 @@ const RegistryCard: React.FC<RegistryCardProps> = ({ item, onClick, isAdmin, onE
   const status = getRegistryItemStatus(item);
   const isClaimed = status === 'claimed' || status === 'fullyFunded';
   // Updated card styling, removed dark mode, updated focus ring
-  const cardClasses = `border border-rose-100 rounded-2xl overflow-hidden shadow-md hover:shadow-xl transition relative bg-white text-[#374151] focus-within:ring-4 focus-within:ring-rose-300 outline-none ${isClaimed ? 'opacity-60' : ''}`;
+  const cardClasses = `border border-rose-100 rounded-2xl overflow-hidden shadow-md hover:shadow-xl transition relative bg-white text-[var(--color-foreground)] focus-within:ring-4 focus-within:ring-rose-300 outline-none ${isClaimed ? 'opacity-60' : ''}`;
   const isClickable = !isClaimed && !isAdmin;
 
   const handleEditClick = (e: React.MouseEvent) => {


### PR DESCRIPTION
## Summary
- detect user's color scheme via `prefers-color-scheme`
- define dark theme palette variables
- use theme variables for page backgrounds and text

## Testing
- `npm test` *(fails: prisma not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862fbd513ec832cbb51f0ca1ae7957d