### PR TITLE
Add automatic dark theme

### DIFF
--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -32,14 +32,14 @@ export default function AdminDashboardPage() {
 
   if (loading) return (
     // Updated background
-    <main className="min-h-screen flex items-center justify-center bg-[#fffdfc]">
+    <main className="min-h-screen flex items-center justify-center bg-[var(--color-background)] text-[var(--color-foreground)]">
       <h1 className="text-3xl font-bold mb-4 text-rose-700">Admin Dashboard</h1>
       <p className="text-lg text-gray-500">Loading items...</p>
     </main>
   );
   if (error) return (
     // Updated background
-    <main className="min-h-screen flex items-center justify-center bg-[#fffdfc]">
+    <main className="min-h-screen flex items-center justify-center bg-[var(--color-background)] text-[var(--color-foreground)]">
       <h1 className="text-3xl font-bold mb-4 text-rose-700">Admin Dashboard</h1>
       <p className="text-red-500 text-lg">Error: {error}</p>
     </main>
@@ -47,14 +47,14 @@ export default function AdminDashboardPage() {
 
   return (
     // Updated background, removed dark mode
-    <main className="min-h-screen bg-[#fffdfc] py-10 px-2 sm:px-6">
+    <main className="min-h-screen bg-[var(--color-background)] text-[var(--color-foreground)] py-10 px-2 sm:px-6">
       <div className="max-w-5xl mx-auto">
         {/* Updated heading color */}
         <h1 className="text-4xl font-extrabold mb-8 text-center text-rose-700 tracking-tight drop-shadow-lg">Admin Dashboard</h1>
         {/* Responsive Table for Desktop, Cards for Mobile */}
         <div className="hidden md:block">
           {/* Updated table container styles */}
-          <div className="overflow-x-auto rounded-xl shadow-lg bg-white border border-rose-100">
+          <div className="overflow-x-auto rounded-xl shadow-lg bg-white dark:bg-gray-800 border border-rose-100 dark:border-gray-700">
             {/* Updated table styles */}
             <table className="min-w-full divide-y divide-rose-100">
               {/* Updated table header styles */}
@@ -123,7 +123,7 @@ export default function AdminDashboardPage() {
         <div className="md:hidden space-y-6">
           {items.map((item) => (
             // Updated card styles
-            <div key={item.id} className="rounded-xl shadow-lg bg-white p-4 flex flex-col gap-2 border border-rose-100">
+            <div key={item.id} className="rounded-xl shadow-lg bg-white dark:bg-gray-800 p-4 flex flex-col gap-2 border border-rose-100 dark:border-gray-700">
               <div className="flex justify-between items-center mb-2">
                 {/* Updated item name color */}
                 <span className="font-bold text-lg text-rose-700">{item.name}</span>

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -33,8 +33,8 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-[#fffdfc] px-2">
-      <form onSubmit={handleLogin} className="w-full max-w-md bg-white rounded-2xl shadow-2xl p-8 sm:p-10 flex flex-col gap-6 border border-rose-100">
+    <div className="min-h-screen flex items-center justify-center bg-[var(--color-background)] px-2 text-[var(--color-foreground)]">
+      <form onSubmit={handleLogin} className="w-full max-w-md bg-white dark:bg-gray-800 rounded-2xl shadow-2xl p-8 sm:p-10 flex flex-col gap-6 border border-rose-100 dark:border-gray-700">
         <h1 className="text-3xl font-extrabold text-center text-rose-700 mb-2 tracking-tight">Admin Login</h1>
         {error && <p className="text-red-500 text-sm text-center -mt-2">{error}</p>}
         <div className="flex flex-col gap-2">
@@ -44,7 +44,7 @@ export default function LoginPage() {
             id="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="border border-gray-300 p-3 rounded-lg w-full focus:ring-2 focus:ring-rose-300 outline-none bg-white text-lg"
+            className="border border-gray-300 dark:border-gray-600 p-3 rounded-lg w-full focus:ring-2 focus:ring-rose-300 outline-none bg-white dark:bg-gray-700 text-lg text-gray-800 dark:text-gray-100"
             required
             autoFocus
             autoComplete="current-password"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,6 +15,19 @@
   --font-mono: var(--font-geist-mono);
 }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #111827; /* gray-900 */
+    --foreground: #f9fafb; /* gray-50 */
+    --color-primary: #f43f5e; /* rose-500 for better contrast */
+    --color-secondary: #fbbf24; /* amber-400 */
+    --color-accent-from: #f43f5e;
+    --color-accent-to: #fbbf24;
+    --color-text-on-primary: #ffffff;
+    --color-text-on-secondary: #1f2937; /* gray-800 */
+  }
+}
+
 body {
   background: var(--background);
   color: var(--foreground);
@@ -25,6 +38,11 @@ input, textarea, select {
   color: var(--color-foreground);
   background: var(--color-background);
   border-color: #e5e7eb; /* gray-200 for default borders */
+}
+@media (prefers-color-scheme: dark) {
+  input, textarea, select {
+    border-color: #4b5563; /* gray-600 */
+  }
 }
 input:focus, textarea:focus, select:focus {
   border-color: var(--color-primary); /* rose-700 */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -68,7 +68,9 @@ export default function RootLayout({
         <link rel="icon" href="/assets/favicon.png" type="image/png" />
       </Head>
       {/* Apply base theme colors directly to body */}
-      <body className={`${geist.variable} bg-[#fffdfc] text-[#374151] selection:bg-rose-100 selection:text-rose-900`}>
+      <body
+        className={`${geist.variable} bg-[var(--color-background)] text-[var(--color-foreground)] selection:bg-rose-100 selection:text-rose-900 dark:selection:bg-rose-800`}
+      >
         <QueryClientProvider client={queryClient}>
           {loading && <LoadingScreen />}
           {/* Admin Indicator and Logout Button - Restyled */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -67,7 +67,7 @@ export default function HomePage() {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
 
       {/* Global wrapper provides consistent background */}
-      <div className="min-h-screen bg-[#fffdfc] text-[#374151] selection:bg-rose-100 selection:text-rose-900">
+      <div className="min-h-screen bg-[var(--color-background)] text-[var(--color-foreground)] selection:bg-rose-100 selection:text-rose-900 dark:selection:bg-rose-800">
         {/* -------------------------------------------------------------- */}
         {/* Hero                                                          */}
         {/* -------------------------------------------------------------- */}

--- a/src/app/project-info/page.tsx
+++ b/src/app/project-info/page.tsx
@@ -29,7 +29,7 @@ const sectionVariants = {
 
 const ProjectInfo = () => {
   return (
-    <div className="min-h-screen bg-[#fffdfc] text-[#374151] selection:bg-rose-100 selection:text-rose-900 pb-24">
+    <div className="min-h-screen bg-[var(--color-background)] text-[var(--color-foreground)] selection:bg-rose-100 selection:text-rose-900 dark:selection:bg-rose-800 pb-24">
       {/* Hero Section */}
       <motion.div
         className="max-w-3xl mx-auto text-center py-20 px-4"
@@ -62,7 +62,7 @@ const ProjectInfo = () => {
         variants={sectionVariants}
         custom={1}
       >
-        <div className="bg-white rounded-2xl shadow-xl p-10 flex flex-col items-center border border-rose-100">
+        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-10 flex flex-col items-center border border-rose-100 dark:border-gray-700">
           <h2 className="text-2xl font-bold mb-6 text-rose-700 tracking-tight">&quot;Features&quot; (Allegedly)</h2>
           <ul className="space-y-4 w-full">
             {features.map(f => (
@@ -72,7 +72,7 @@ const ProjectInfo = () => {
             ))}
           </ul>
         </div>
-        <div className="bg-white rounded-2xl shadow-xl p-10 flex flex-col items-center border border-amber-100">
+        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-10 flex flex-col items-center border border-amber-100 dark:border-gray-700">
           <h2 className="text-2xl font-bold mb-6 text-amber-600 tracking-tight">Tech I Used (And Sometimes Regretted)</h2>
           <ul className="space-y-4 w-full">
             {techStack.map(t => (
@@ -93,7 +93,7 @@ const ProjectInfo = () => {
         variants={sectionVariants}
         custom={2}
       >
-        <div className="bg-white rounded-2xl shadow-xl p-10 border border-gray-200">
+        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-10 border border-gray-200 dark:border-gray-700">
           <h2 className="text-2xl font-bold mb-4 text-rose-700 tracking-tight">How It&apos;s Cobbled Together</h2>
           <ul className="list-disc pl-6 text-gray-700 space-y-2">
             <li><strong>Landing Page:</strong> Standard wedding stuff, plus a heart that spins. Fancy.</li>
@@ -108,7 +108,7 @@ const ProjectInfo = () => {
 
       {/* Deployment & Contribution */}
       <div className="max-w-4xl mx-auto mt-12 px-4 grid md:grid-cols-2 gap-8">
-        <div className="bg-white rounded-2xl shadow-xl p-8 flex flex-col border border-gray-200">
+        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-8 flex flex-col border border-gray-200 dark:border-gray-700">
           <h2 className="text-xl font-bold mb-3 text-rose-700">Making It Go Live (Good Luck)</h2>
           <ul className="list-disc pl-6 text-gray-700 space-y-2">
             <li>Deploy easily to <a href='https://vercel.com/' className='underline text-rose-600 hover:text-rose-800' target='_blank' rel='noopener noreferrer'>Vercel</a> or <a href='https://www.netlify.com/' className='underline text-rose-600 hover:text-rose-800' target='_blank' rel='noopener noreferrer'>Netlify</a>.</li>
@@ -117,7 +117,7 @@ const ProjectInfo = () => {
             <li>See <a href='https://github.com/fderuiter/wedding_website#readme' className='underline text-rose-600 hover:text-rose-800' target='_blank' rel='noopener noreferrer'>README</a> for full setup instructions.</li>
           </ul>
         </div>
-        <div className="bg-white rounded-2xl shadow-xl p-8 flex flex-col border border-gray-200">
+        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-8 flex flex-col border border-gray-200 dark:border-gray-700">
           <h2 className="text-xl font-bold mb-3 text-amber-600">&quot;Contributing&quot; (Why?)</h2>
           <ul className="list-disc pl-6 text-gray-700 space-y-2">
             <li>It&apos;s open source. Feel free to point and laugh on GitHub.</li>

--- a/src/app/registry/page.tsx
+++ b/src/app/registry/page.tsx
@@ -182,7 +182,7 @@ export default function RegistryPage() {
 
   return (
     // Updated background to match main page
-    <div className="min-h-screen bg-[#fffdfc] text-[#374151] selection:bg-rose-100 selection:text-rose-900 pb-32 px-2 sm:px-4">
+    <div className="min-h-screen bg-[var(--color-background)] text-[var(--color-foreground)] selection:bg-rose-100 selection:text-rose-900 dark:selection:bg-rose-800 pb-32 px-2 sm:px-4">
       <motion.h1
         // Updated heading color to rose-700
         className="text-5xl font-extrabold text-center mb-12 pt-12 text-rose-700 tracking-tight drop-shadow-lg"
@@ -197,7 +197,7 @@ export default function RegistryPage() {
       {/* Enhanced Filter Bar - Updated styles */}
       <nav
         // Updated background, border, removed dark mode
-        className="sticky top-0 z-30 bg-white/90 backdrop-blur border-b border-rose-100 max-w-4xl mx-auto px-2 sm:px-6 mb-10 flex flex-col gap-4 py-4 rounded-xl shadow-md"
+        className="sticky top-0 z-30 bg-white/90 dark:bg-gray-800/90 backdrop-blur border-b border-rose-100 dark:border-gray-700 max-w-4xl mx-auto px-2 sm:px-6 mb-10 flex flex-col gap-4 py-4 rounded-xl shadow-md"
         aria-label="Registry Filters"
         role="navigation"
       >
@@ -265,7 +265,7 @@ export default function RegistryPage() {
               <button
                 onClick={handleCloseModal}
                 // Updated close button style
-                className="bg-white rounded-full p-2 shadow-lg border border-gray-200 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-rose-400"
+                className="bg-white dark:bg-gray-800 rounded-full p-2 shadow-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-rose-400"
                 aria-label="Close modal"
                 tabIndex={0}
               >

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -99,8 +99,8 @@ const Modal: React.FC<ModalProps> = ({ item, onClose, onContribute }) => {
   return (
     // Updated backdrop
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-60 z-50 p-4" role="dialog" aria-modal="true" ref={modalRef}>
-      {/* Updated modal background and text color, removed dark mode */}
-      <div className="bg-white rounded-lg shadow-xl max-w-xl w-full p-6 relative max-h-[90vh] overflow-y-auto text-[#374151]">
+      {/* Updated modal background and text color */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-xl w-full p-6 relative max-h-[90vh] overflow-y-auto text-gray-800 dark:text-gray-100">
         {/* Close Button - Adjusted color */}
         <button
           className="absolute top-3 right-3 text-gray-500 hover:text-rose-600 text-2xl font-bold"
@@ -167,7 +167,7 @@ const Modal: React.FC<ModalProps> = ({ item, onClose, onContribute }) => {
               type="text"
               placeholder="Your Name"
               // Updated input styles
-              className="border border-gray-300 p-2 rounded w-full mb-3 focus:ring-2 focus:ring-rose-400 outline-none bg-white text-[#374151]"
+              className="border border-gray-300 dark:border-gray-600 p-2 rounded w-full mb-3 focus:ring-2 focus:ring-rose-400 outline-none bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100"
               value={contributorName}
               onChange={(e) => setContributorName(e.target.value)}
               disabled={isSubmitting}
@@ -177,7 +177,7 @@ const Modal: React.FC<ModalProps> = ({ item, onClose, onContribute }) => {
                 type="number"
                 placeholder={`Contribution Amount (up to $${remainingAmount.toFixed(2)})`}
                 // Updated input styles
-                className="border border-gray-300 p-2 rounded w-full mb-3 focus:ring-2 focus:ring-rose-400 outline-none bg-white text-[#374151]"
+                className="border border-gray-300 dark:border-gray-600 p-2 rounded w-full mb-3 focus:ring-2 focus:ring-rose-400 outline-none bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100"
                 value={amount}
                 onChange={(e) => setAmount(e.target.value)}
                 min="0.01"

--- a/src/components/RegistryCard.tsx
+++ b/src/components/RegistryCard.tsx
@@ -16,7 +16,7 @@ const RegistryCard: React.FC<RegistryCardProps> = ({ item, onClick, isAdmin, onE
   const status = getRegistryItemStatus(item);
   const isClaimed = status === 'claimed' || status === 'fullyFunded';
   // Updated card styling, removed dark mode, updated focus ring
-  const cardClasses = `border border-rose-100 rounded-2xl overflow-hidden shadow-md hover:shadow-xl transition relative bg-white text-[#374151] focus-within:ring-4 focus-within:ring-rose-300 outline-none ${isClaimed ? 'opacity-60' : ''}`;
+  const cardClasses = `border border-rose-100 dark:border-gray-700 rounded-2xl overflow-hidden shadow-md hover:shadow-xl transition relative bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 focus-within:ring-4 focus-within:ring-rose-300 outline-none ${isClaimed ? 'opacity-60' : ''}`;
   const isClickable = !isClaimed && !isAdmin;
 
   const handleEditClick = (e: React.MouseEvent) => {

--- a/src/components/RegistryItemForm.tsx
+++ b/src/components/RegistryItemForm.tsx
@@ -90,7 +90,7 @@ const RegistryItemForm: React.FC<RegistryItemFormProps> = ({
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4 max-w-lg mx-auto bg-white p-6 rounded shadow" data-testid="form">
+    <form onSubmit={handleSubmit} className="space-y-4 max-w-lg mx-auto bg-white dark:bg-gray-800 p-6 rounded shadow" data-testid="form">
       {mode === 'add' && (
         <div className="mb-4">
           <label htmlFor="scrapeUrl" className="block text-sm font-medium text-gray-700">Import from Product URL:</label>
@@ -102,7 +102,7 @@ const RegistryItemForm: React.FC<RegistryItemFormProps> = ({
               value={scrapeUrl}
               onChange={e => setScrapeUrl(e.target.value)}
               placeholder="https://..."
-              className="flex-1 rounded border-gray-300 p-2 border"
+              className="flex-1 rounded border-gray-300 dark:border-gray-600 p-2 border bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100"
               disabled={scrapeLoading}
             />
             <button
@@ -119,34 +119,34 @@ const RegistryItemForm: React.FC<RegistryItemFormProps> = ({
       )}
       <div>
         <label htmlFor="name" className="block text-sm font-medium text-gray-700">Item Name:</label>
-        <input type="text" id="name" name="name" value={values.name || ''} onChange={handleChange} required className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border" />
+        <input type="text" id="name" name="name" value={values.name || ''} onChange={handleChange} required className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100" />
       </div>
       <div>
         <label htmlFor="description" className="block text-sm font-medium text-gray-700">Description:</label>
-        <textarea id="description" name="description" value={values.description || ''} onChange={handleChange} rows={3} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border"></textarea>
+        <textarea id="description" name="description" value={values.description || ''} onChange={handleChange} rows={3} className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100"></textarea>
       </div>
       <div>
         <label htmlFor="price" className="block text-sm font-medium text-gray-700">Price ($):</label>
-        <input type="number" id="price" name="price" value={values.price ?? ''} onChange={handleChange} step="0.01" required className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border" />
+        <input type="number" id="price" name="price" value={values.price ?? ''} onChange={handleChange} step="0.01" required className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100" />
       </div>
       <div>
         <label htmlFor="quantity" className="block text-sm font-medium text-gray-700">Quantity:</label>
-        <input type="number" id="quantity" name="quantity" value={values.quantity ?? 1} onChange={handleChange} required className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border" />
+        <input type="number" id="quantity" name="quantity" value={values.quantity ?? 1} onChange={handleChange} required className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100" />
       </div>
       <div>
         <label htmlFor="category" className="block text-sm font-medium text-gray-700">Category:</label>
-        <input type="text" id="category" name="category" value={values.category || ''} onChange={handleChange} required className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border" />
+        <input type="text" id="category" name="category" value={values.category || ''} onChange={handleChange} required className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100" />
       </div>
       <div>
         <label htmlFor="image" className="block text-sm font-medium text-gray-700">Image URL:</label>
-        <input type="url" id="image" name="image" value={values.image || ''} onChange={handleChange} placeholder="https://..." className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border" />
+        <input type="url" id="image" name="image" value={values.image || ''} onChange={handleChange} placeholder="https://..." className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100" />
       </div>
       <div>
         <label htmlFor="vendorUrl" className="block text-sm font-medium text-gray-700">Vendor/Product URL:</label>
-        <input type="url" id="vendorUrl" name="vendorUrl" value={values.vendorUrl || ''} onChange={handleChange} placeholder="https://..." className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border" />
+        <input type="url" id="vendorUrl" name="vendorUrl" value={values.vendorUrl || ''} onChange={handleChange} placeholder="https://..." className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100" />
       </div>
       <div className="flex items-center">
-        <input type="checkbox" id="isGroupGift" name="isGroupGift" checked={!!values.isGroupGift} onChange={handleChange} className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500" />
+        <input type="checkbox" id="isGroupGift" name="isGroupGift" checked={!!values.isGroupGift} onChange={handleChange} className="h-4 w-4 text-indigo-600 border-gray-300 dark:border-gray-600 rounded focus:ring-indigo-500" />
         <label htmlFor="isGroupGift" className="ml-2 block text-sm text-gray-900">Allow Group Gifting?</label>
       </div>
       {formError && <p className="text-red-500 text-sm mt-2">{formError}</p>}


### PR DESCRIPTION
## Summary
- support `prefers-color-scheme` in global CSS
- use theme variables on the `<body>` element
- apply dark-aware styles to major pages and registry components
- tweak inputs and modals for readable dark theme

## Testing
- `npm test` *(fails: `prisma` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862fbd513ec832cbb51f0ca1ae7957d