### PR TITLE
Add 3D heart playground page

### DIFF
--- a/src/app/heart/page.tsx
+++ b/src/app/heart/page.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import LoadingScreen from '@/components/LoadingScreen'
+
+const WeddingIntro = dynamic(() => import('@/components/WeddingIntro'), {
+  ssr: false,
+  loading: () => <LoadingScreen />,
+})
+
+export default function HeartScenePage() {
+  return <WeddingIntro />
+}


### PR DESCRIPTION
## Summary
- add a new /heart page that displays the spinning 3D heart scene

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68648e60a34c832c9a32dab35fe869a7