### PR TITLE
Add coverage tests for registry features

### DIFF
--- a/src/app/api/registry/__tests__/route.test.ts
+++ b/src/app/api/registry/__tests__/route.test.ts
@@ -1,0 +1,22 @@
+jest.mock('next/server', () => ({
+  NextResponse: { json: jest.fn((data, init) => ({ status: init?.status || 200, json: () => data })) }
+}));
+
+jest.mock('../../../../services/registryService', () => ({
+  RegistryService: { contributeToItem: jest.fn() }
+}));
+
+// Import after mocks
+import { POST } from '../contribute/route';
+
+describe('POST /api/registry/contribute', () => {
+  it('returns 400 on invalid payload', async () => {
+    const req = {
+      json: async () => ({}),
+    } as unknown as Request;
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBeDefined();
+  });
+});

--- a/src/app/registry/__tests__/page.test.tsx
+++ b/src/app/registry/__tests__/page.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import RegistryPage from '../page';
+import type { Contributor } from '@/types/registry';
+
+jest.mock('next/image', () => {
+  /* eslint-disable @next/next/no-img-element, @typescript-eslint/no-explicit-any */
+  const MockImage = (props: any) => <img {...props} alt={props.alt || ''} />;
+  MockImage.displayName = 'NextImage';
+  return MockImage;
+});
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() })
+}));
+
+const items = [
+  {
+    id: '1',
+    name: 'Gift',
+    description: '',
+    category: 'Other',
+    price: 100,
+    image: '',
+    vendorUrl: null,
+    quantity: 1,
+    isGroupGift: true,
+    purchased: false,
+    purchaserName: null,
+    amountContributed: 0,
+    contributors: [] as Contributor[]
+  }
+];
+
+function setupFetch() {
+  // minimal Response shape for fetch mocks
+  type MockRes = { ok: boolean; json: () => Promise<unknown> };
+  let resolveContribute: (v: MockRes) => void;
+  const contributePromise = new Promise<MockRes>((res) => {
+    resolveContribute = res;
+  });
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  global.fetch = jest.fn((url: string, _opts?: RequestInit) => {
+    if (url.endsWith('/api/registry/items')) {
+      return Promise.resolve({ ok: true, json: async () => items } as MockRes);
+    }
+    if (url.endsWith('/api/registry/contribute')) {
+      return contributePromise;
+    }
+    return Promise.resolve({ ok: false, json: async () => ({}) } as MockRes);
+  });
+  return { resolveContribute: resolveContribute! };
+}
+
+describe('RegistryPage optimistic contribution', () => {
+  it('updates UI optimistically after contributing', async () => {
+    const { resolveContribute } = setupFetch();
+    localStorage.setItem('isAdminLoggedIn', 'false');
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <RegistryPage />
+      </QueryClientProvider>
+    );
+
+    // Wait for items to load
+    await waitFor(() => expect(screen.getByTestId('registry-card')).toBeInTheDocument());
+    expect(screen.getByText(/Group Gift:/)).toHaveTextContent('$0.00');
+
+    fireEvent.click(screen.getByTestId('registry-card'));
+
+    await waitFor(() => expect(screen.getAllByRole('dialog').length).toBeGreaterThan(0));
+
+    fireEvent.change(screen.getByPlaceholderText('Your Name'), { target: { value: 'Alice' } });
+    fireEvent.change(screen.getByPlaceholderText(/Contribution Amount/), { target: { value: '20' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit Contribution' }));
+
+    // Optimistic UI should update before resolve
+    await waitFor(() => expect(screen.getByText(/Group Gift:/)).toHaveTextContent('$20.00'));
+
+    // complete fetch
+    resolveContribute({ ok: true, json: async () => items[0] });
+  });
+});

--- a/src/services/__tests__/registryService.test.ts
+++ b/src/services/__tests__/registryService.test.ts
@@ -1,0 +1,96 @@
+import { RegistryService } from '../registryService';
+import { prisma } from '../../lib/prisma';
+import type { Contributor, RegistryItem } from '@/types/registry';
+
+jest.mock('../../lib/prisma', () => ({
+  prisma: {
+    registryItem: {
+      findMany: jest.fn(),
+      update: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+    },
+    $transaction: jest.fn()
+  }
+}));
+
+describe('RegistryService.contributeToItem', () => {
+  it('updates contribution and returns remaining balance', async () => {
+    const item = {
+      id: '1',
+      name: 'Gift',
+      description: '',
+      category: 'Other',
+      price: 100,
+      image: '',
+      vendorUrl: null,
+      quantity: 1,
+      isGroupGift: true,
+      purchased: false,
+      purchaserName: null,
+      amountContributed: 40,
+      contributors: [] as Contributor[]
+    };
+    const updatedItem = {
+      ...item,
+      amountContributed: 70,
+      purchased: false,
+      contributors: [{ name: 'Alice', amount: 30, date: new Date().toISOString() }]
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (prisma.$transaction as jest.Mock).mockImplementation(async (cb: any) => {
+      const tx = {
+        registryItem: {
+          findUnique: jest.fn().mockResolvedValue(item),
+          update: jest.fn().mockResolvedValue(updatedItem)
+        }
+      };
+      return cb(tx);
+    });
+
+    const result = await RegistryService.contributeToItem('1', {
+      name: 'Alice',
+      amount: 30
+    });
+
+    expect(result.amountContributed).toBe(70);
+    expect(result.purchased).toBe(false);
+    const remaining = result.price - result.amountContributed;
+    expect(remaining).toBe(30);
+  });
+});
+
+describe('RegistryService basic methods', () => {
+  it('returns all items', async () => {
+    const items = [{ id: '1' }];
+    (prisma.registryItem.findMany as jest.Mock).mockResolvedValue(items);
+    const result = await RegistryService.getAllItems();
+    expect(result).toEqual(items);
+    expect(prisma.registryItem.findMany).toHaveBeenCalled();
+  });
+
+  it('updates an item without contributors field', async () => {
+    const updated = { id: '1', name: 'New' };
+    (prisma.registryItem.update as jest.Mock).mockResolvedValue(updated);
+    const result = await RegistryService.updateItem('1', { name: 'New', contributors: [] as Contributor[] });
+    expect(result).toEqual(updated);
+    expect(prisma.registryItem.update).toHaveBeenCalledWith({
+      where: { id: '1' },
+      data: { name: 'New' },
+      include: { contributors: true }
+    });
+  });
+
+  it('creates and deletes an item', async () => {
+    const itemData: Omit<RegistryItem, 'id' | 'contributors'> = { name: 'G', description: '', category: 'Other', price: 1, image: '', vendorUrl: null, quantity: 1, isGroupGift: false, purchased: false, purchaserName: null, amountContributed: 0 };
+    const createdItem = { id: '2', ...itemData, contributors: [] };
+    (prisma.registryItem.create as jest.Mock).mockResolvedValue(createdItem);
+    const result = await RegistryService.createItem(itemData);
+    expect(result).toEqual(createdItem);
+    expect(prisma.registryItem.create).toHaveBeenCalled();
+    (prisma.registryItem.delete as jest.Mock).mockResolvedValue({});
+    await RegistryService.deleteItem('2');
+    expect(prisma.registryItem.delete).toHaveBeenCalledWith({ where: { id: '2' } });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for RegistryService using mocked Prisma
- add test for contribute API route
- add page integration test to verify optimistic registry updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68654b59ef7c832c837e80204de7b21f