### PR TITLE
Fix slider flash of unstyled content

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "../../node_modules/add-to-calendar-button/assets/css/atcb.css";
+@import "../../node_modules/keen-slider/keen-slider.min.css";
 
 :root {
   --background: #111827; /* gray-900 */

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -198,6 +198,11 @@ export default function HomePage() {
           <a href="/registry" className="inline-block rounded-full bg-gradient-to-r from-rose-700 to-amber-500 px-10 py-4 font-medium text-white shadow-lg transition hover:scale-105 hover:shadow-xl">View Registry</a>
         </motion.section>
 
+        {/* Additional Gallery */}
+        <motion.section className="py-10" initial="hidden" whileInView="visible" viewport={{ once: true }} variants={fadeUp} custom={2.1}>
+          <Gallery images={galleryImages} />
+        </motion.section>
+
         {/* -------------------------------------------------------------- */}
         {/* Footer                                                       */}
         {/* -------------------------------------------------------------- */}

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import { useKeenSlider } from 'keen-slider/react';
-import 'keen-slider/keen-slider.min.css';
 
 export interface GalleryImage {
   src: string;
@@ -15,8 +14,10 @@ interface GalleryProps {
 
 const Gallery: React.FC<GalleryProps> = ({ images, autoplayDelay = 3000 }) => {
   const timer = useRef<NodeJS.Timeout | null>(null);
+  const [loaded, setLoaded] = useState(false);
   const [sliderRef, instanceRef] = useKeenSlider<HTMLDivElement>({
     loop: true,
+    created: () => setLoaded(true),
   });
 
   useEffect(() => {
@@ -27,10 +28,28 @@ const Gallery: React.FC<GalleryProps> = ({ images, autoplayDelay = 3000 }) => {
     };
   }, [instanceRef, autoplayDelay]);
 
+  if (!loaded) {
+    return (
+      <div
+        ref={sliderRef}
+        className="keen-slider aspect-square w-full max-w-lg mx-auto rounded-lg overflow-hidden"
+        style={{ display: 'flex', overflow: 'hidden', position: 'relative' }}
+      />
+    );
+  }
+
   return (
-    <div ref={sliderRef} className="keen-slider aspect-square w-full max-w-lg mx-auto rounded-lg overflow-hidden">
+    <div
+      ref={sliderRef}
+      className="keen-slider aspect-square w-full max-w-lg mx-auto rounded-lg overflow-hidden"
+      style={{ display: 'flex', overflow: 'hidden', position: 'relative' }}
+    >
       {images.map((img, idx) => (
-        <div className="keen-slider__slide flex items-center justify-center" key={idx}>
+        <div
+          className="keen-slider__slide flex items-center justify-center"
+          key={idx}
+          style={{ minHeight: '100%', width: '100%', position: 'relative' }}
+        >
           <Image src={img.src} alt={img.alt} width={600} height={600} className="object-cover w-full h-full" />
         </div>
       ))}


### PR DESCRIPTION
## Summary
- load Keen Slider CSS from global stylesheet
- add fallback styles and loading state to gallery so slides size correctly before styles load
- add a second gallery near the bottom of the homepage

## Testing
- `npm test` *(fails: prisma not found)*

------
https://chatgpt.com/codex/tasks/task_e_68799dd09e90832ca5d041151bfc9d6d