### PR TITLE
Center header nav and clean up overflow

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,7 +15,7 @@
   --color-text-on-secondary: #1f2937; /* gray-800 */
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-  --header-h: 64px; /* Height of sticky header */
+  --header-h: 56px; /* Height of sticky header */
 }
 
 body {
@@ -96,4 +96,35 @@ html:focus-within {
   padding: .5rem .75rem;
   border-radius: .375rem;
   box-shadow: 0 2px 6px rgba(0,0,0,.15);
+}
+
+/* Hide scrollbar utility */
+.scrollbar-none {
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+}
+.scrollbar-none::-webkit-scrollbar {
+  display: none; /* Chrome, Safari */
+}
+
+/* Fading edges for horizontally scrollable nav */
+.nav-scroll-fade {
+  position: relative;
+}
+.nav-scroll-fade::before,
+.nav-scroll-fade::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1rem;
+  pointer-events: none;
+}
+.nav-scroll-fade::before {
+  left: 0;
+  background: linear-gradient(to right, var(--background), transparent);
+}
+.nav-scroll-fade::after {
+  right: 0;
+  background: linear-gradient(to left, var(--background), transparent);
 }

--- a/src/components/StickyHeader.tsx
+++ b/src/components/StickyHeader.tsx
@@ -62,21 +62,28 @@ export default function StickyHeader() {
   return (
     <header
       className={[
-        'sticky top-0 z-40',
+        'sticky top-0 z-40 h-14',
         'backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:supports-[backdrop-filter]:bg-neutral-900/60',
-        'supports-[backdrop-filter]:shadow-sm',
+        'border-b border-white/10',
       ].join(' ')}
-      style={{ height: 'var(--header-h)' }}
+      style={{ height: 'var(--header-h, 56px)' }}
     >
       {/* Skip to content (first tabbable item on the page) */}
       <a href="#main" className="skip-link">Skip to content</a>
 
       <nav
-        className="mx-auto max-w-5xl h-[var(--header-h)] flex items-center px-3"
-        role="navigation"
-        aria-label="Section"
+        className="mx-auto w-full max-w-5xl h-full flex items-center px-3"
+        aria-label="Section navigation"
       >
-        <ul className="flex items-center gap-1 overflow-x-auto">{items}</ul>
+        <ul
+          className={[
+            'flex min-w-0 items-center gap-1 justify-center',
+            'max-sm:overflow-x-auto max-sm:scrollbar-none max-sm:justify-start',
+            'nav-scroll-fade',
+          ].join(' ')}
+        >
+          {items}
+        </ul>
       </nav>
     </header>
   );


### PR DESCRIPTION
## Summary
- center the sticky nav bar links and limit overflow to small screens only
- drop header height to `56px` for stable layout
- add optional fade effect and scrollbar hiding utilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b80ca5e40832ca7e20ce6c85d5115