### PR TITLE
test: add admin auth utility tests

### DIFF
--- a/src/utils/__tests__/adminAuth.test.ts
+++ b/src/utils/__tests__/adminAuth.test.ts
@@ -1,0 +1,56 @@
+import type { NextRequest } from 'next/server';
+import { isAdminClient } from '../adminAuth.client';
+import { isAdminRequest } from '../adminAuth.server';
+
+describe('admin authentication helpers', () => {
+  describe('isAdminClient', () => {
+    afterEach(() => {
+      Object.defineProperty(document, 'cookie', {
+        writable: true,
+        value: '',
+      });
+    });
+
+    it('returns true when admin cookie is present', () => {
+      Object.defineProperty(document, 'cookie', {
+        writable: true,
+        value: 'admin_auth=true',
+      });
+      expect(isAdminClient()).toBe(true);
+    });
+
+    it('returns false when admin cookie is absent', () => {
+      Object.defineProperty(document, 'cookie', {
+        writable: true,
+        value: '',
+      });
+      expect(isAdminClient()).toBe(false);
+    });
+  });
+
+  describe('isAdminRequest', () => {
+    it('returns true for request with admin cookie', async () => {
+      const req = {
+        cookies: {
+          get: () => ({ value: 'true' }),
+        },
+        headers: {
+          get: () => 'admin_auth=true',
+        },
+      } as unknown as NextRequest;
+      await expect(isAdminRequest(req)).resolves.toBe(true);
+    });
+
+    it('returns false for request without admin cookie', async () => {
+      const req = {
+        cookies: {
+          get: () => undefined,
+        },
+        headers: {
+          get: () => null,
+        },
+      } as unknown as NextRequest;
+      await expect(isAdminRequest(req)).resolves.toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for admin authentication utilities
- cover client-side and request-based checks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e04615fb0832cacf4d54ba8a6c13b