### PR TITLE
test: add coverage for registry utilities

### DIFF
--- a/src/components/__tests__/filterUtils.test.ts
+++ b/src/components/__tests__/filterUtils.test.ts
@@ -1,0 +1,67 @@
+import { filterRegistryItems } from '../filterUtils';
+import { RegistryItem } from '@/types/registry';
+
+describe('filterRegistryItems', () => {
+  const items: RegistryItem[] = [
+    {
+      id: '1',
+      name: 'Toaster',
+      description: 'Kitchen appliance',
+      category: 'Kitchen',
+      price: 25,
+      image: '/toaster.jpg',
+      vendorUrl: null,
+      quantity: 1,
+      isGroupGift: false,
+      purchased: false,
+      amountContributed: 0,
+      contributors: [],
+    },
+    {
+      id: '2',
+      name: 'Vacuum',
+      description: 'Home cleaning',
+      category: 'Home',
+      price: 150,
+      image: '/vacuum.jpg',
+      vendorUrl: null,
+      quantity: 1,
+      isGroupGift: false,
+      purchased: false,
+      amountContributed: 0,
+      contributors: [],
+    },
+    {
+      id: '3',
+      name: 'Luggage',
+      description: 'Travel gear',
+      category: 'Travel',
+      price: 300,
+      image: '/luggage.jpg',
+      vendorUrl: null,
+      quantity: 1,
+      isGroupGift: true,
+      purchased: false,
+      amountContributed: 0,
+      contributors: [],
+    },
+  ];
+
+  it('filters items by category', () => {
+    const result = filterRegistryItems(items, ['Kitchen'], [0, 1000]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('1');
+  });
+
+  it('filters items by price range', () => {
+    const result = filterRegistryItems(items, [], [100, 200]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('2');
+  });
+
+  it('filters items by category and price range', () => {
+    const result = filterRegistryItems(items, ['Travel'], [200, 400]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('3');
+  });
+});

--- a/src/components/__tests__/registryStatusUtils.test.ts
+++ b/src/components/__tests__/registryStatusUtils.test.ts
@@ -1,0 +1,34 @@
+import { getRegistryItemStatus } from '../registryStatusUtils';
+import { RegistryItem } from '@/types/registry';
+
+describe('getRegistryItemStatus', () => {
+  const baseItem: RegistryItem = {
+    id: '1',
+    name: 'Generic Item',
+    description: 'desc',
+    category: 'General',
+    price: 100,
+    image: '/image.jpg',
+    vendorUrl: null,
+    quantity: 1,
+    isGroupGift: false,
+    purchased: false,
+    amountContributed: 0,
+    contributors: [],
+  };
+
+  it('returns "available" when item not purchased', () => {
+    const status = getRegistryItemStatus(baseItem);
+    expect(status).toBe('available');
+  });
+
+  it('returns "claimed" for purchased single items', () => {
+    const status = getRegistryItemStatus({ ...baseItem, purchased: true });
+    expect(status).toBe('claimed');
+  });
+
+  it('returns "fullyFunded" for purchased group gifts', () => {
+    const status = getRegistryItemStatus({ ...baseItem, purchased: true, isGroupGift: true });
+    expect(status).toBe('fullyFunded');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for filtering registry items by category and price range
- verify registry item status for available, claimed, and fully funded items

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e080e5ae8832cabb3cd9e6832dc9f