### PR TITLE
test: add API route integration tests

### DIFF
--- a/src/app/api/__tests__/adminRoutes.test.ts
+++ b/src/app/api/__tests__/adminRoutes.test.ts
@@ -1,0 +1,56 @@
+/** @jest-environment node */
+
+import { NextRequest } from 'next/server';
+import { POST as login } from '../admin/login/route';
+import { POST as logout } from '../admin/logout/route';
+import { GET as me } from '../admin/me/route';
+
+describe('Admin API routes', () => {
+  beforeEach(() => {
+    process.env.ADMIN_PASSWORD = 'secret';
+  });
+
+  test('login succeeds with correct password', async () => {
+    const req = new NextRequest('http://localhost/api/admin/login', {
+      method: 'POST',
+      body: JSON.stringify({ password: 'secret' }),
+    });
+    const res = await login(req);
+    expect(res.status).toBe(200);
+    expect(res.cookies.get('admin_auth')?.value).toBe('true');
+  });
+
+  test('login fails with invalid password', async () => {
+    const req = new NextRequest('http://localhost/api/admin/login', {
+      method: 'POST',
+      body: JSON.stringify({ password: 'wrong' }),
+    });
+    const res = await login(req);
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toBe('Invalid password.');
+  });
+
+  test('logout clears auth cookie', async () => {
+    const res = await logout();
+    expect(res.status).toBe(200);
+    const setCookie = res.headers.get('set-cookie') ?? '';
+    expect(setCookie).toContain('admin_auth=');
+    expect(setCookie).toContain('Max-Age=0');
+  });
+
+  test('me returns admin status based on cookie', async () => {
+    const reqAdmin = new NextRequest('http://localhost/api/admin/me', {
+      headers: { cookie: 'admin_auth=true' },
+    });
+    const resAdmin = await me(reqAdmin);
+    const jsonAdmin = await resAdmin.json();
+    expect(jsonAdmin.isAdmin).toBe(true);
+
+    const reqAnon = new NextRequest('http://localhost/api/admin/me');
+    const resAnon = await me(reqAnon);
+    const jsonAnon = await resAnon.json();
+    expect(jsonAnon.isAdmin).toBe(false);
+  });
+});
+

--- a/src/app/api/__tests__/registryRoutes.test.ts
+++ b/src/app/api/__tests__/registryRoutes.test.ts
@@ -1,0 +1,143 @@
+/** @jest-environment node */
+
+jest.mock('../../../services/registryService', () => ({
+  RegistryService: {
+    createItem: jest.fn(),
+    contributeToItem: jest.fn(),
+    getAllItems: jest.fn(),
+  },
+}));
+
+jest.mock('../../../utils/adminAuth.server', () => ({
+  isAdminRequest: jest.fn(),
+}));
+
+import { POST as addItem } from '../registry/add-item/route';
+import { POST as contribute } from '../registry/contribute/route';
+import { GET as getItems } from '../registry/items/route';
+import { RegistryService } from '../../../services/registryService';
+import { isAdminRequest } from '../../../utils/adminAuth.server';
+
+const mockCreateItem = RegistryService.createItem as jest.Mock;
+const mockContributeToItem = RegistryService.contributeToItem as jest.Mock;
+const mockGetAllItems = RegistryService.getAllItems as jest.Mock;
+const mockIsAdminRequest = isAdminRequest as jest.Mock;
+
+describe('Registry API routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /api/registry/add-item', () => {
+    const validItem = {
+      name: 'Toaster',
+      price: 50,
+      quantity: 1,
+      category: 'Kitchen',
+    };
+
+    it('returns 401 when unauthorized', async () => {
+      mockIsAdminRequest.mockResolvedValue(false);
+      const req = new Request('http://localhost/api/registry/add-item', {
+        method: 'POST',
+        body: JSON.stringify(validItem),
+      });
+      const res = await addItem(req);
+      expect(res.status).toBe(401);
+      const json = await res.json();
+      expect(json.error).toBe('Unauthorized');
+    });
+
+    it('creates item when authorized and input is valid', async () => {
+      mockIsAdminRequest.mockResolvedValue(true);
+      const created = { id: '1', ...validItem };
+      mockCreateItem.mockResolvedValue(created);
+      const req = new Request('http://localhost/api/registry/add-item', {
+        method: 'POST',
+        body: JSON.stringify(validItem),
+      });
+      const res = await addItem(req);
+      expect(res.status).toBe(201);
+      expect(mockCreateItem).toHaveBeenCalledWith(expect.objectContaining(validItem));
+      const json = await res.json();
+      expect(json.item).toEqual(expect.objectContaining(validItem));
+    });
+
+    it('returns 400 for invalid input', async () => {
+      mockIsAdminRequest.mockResolvedValue(true);
+      const req = new Request('http://localhost/api/registry/add-item', {
+        method: 'POST',
+        body: JSON.stringify({ price: -1 }),
+      });
+      const res = await addItem(req);
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toBeDefined();
+    });
+  });
+
+  describe('POST /api/registry/contribute', () => {
+    const validContribution = {
+      itemId: '1',
+      purchaserName: 'John',
+      amount: 25,
+    };
+
+    it('processes a valid contribution', async () => {
+      mockContributeToItem.mockResolvedValue({ id: '1', amountContributed: 25 });
+      const req = new Request('http://localhost/api/registry/contribute', {
+        method: 'POST',
+        body: JSON.stringify(validContribution),
+      });
+      const res = await contribute(req);
+      expect(res.status).toBe(200);
+      expect(mockContributeToItem).toHaveBeenCalledWith(validContribution.itemId, {
+        name: validContribution.purchaserName,
+        amount: validContribution.amount,
+      });
+    });
+
+    it('returns 400 for invalid data', async () => {
+      const req = new Request('http://localhost/api/registry/contribute', {
+        method: 'POST',
+        body: JSON.stringify({ purchaserName: '', amount: -5 }),
+      });
+      const res = await contribute(req);
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toBeDefined();
+    });
+
+    it('returns 500 when item not found', async () => {
+      mockContributeToItem.mockRejectedValue(new Error('Item not found'));
+      const req = new Request('http://localhost/api/registry/contribute', {
+        method: 'POST',
+        body: JSON.stringify(validContribution),
+      });
+      const res = await contribute(req);
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error).toBe('Item not found');
+    });
+  });
+
+  describe('GET /api/registry/items', () => {
+    it('returns items on success', async () => {
+      const items = [{ id: '1', name: 'Item' }];
+      mockGetAllItems.mockResolvedValue(items);
+      const res = await getItems();
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json).toEqual(items);
+    });
+
+    it('returns 500 on service failure', async () => {
+      mockGetAllItems.mockRejectedValue(new Error('db error'));
+      const res = await getItems();
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error).toBe('Failed to load registry items');
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add integration tests for registry API routes, covering auth, validation, and error handling
- add tests for admin login, logout, and user status endpoints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e0b20bc1c832c97d113e2eb0e2560