### PR TITLE
test: add CategoryFilter tests

### DIFF
--- a/src/components/__tests__/CategoryFilter.test.tsx
+++ b/src/components/__tests__/CategoryFilter.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { CategoryFilter } from '../CategoryFilter';
+
+describe('CategoryFilter', () => {
+  it('renders a checkbox for each category', () => {
+    const categories = ['Kitchen', 'Bedroom', 'Outdoor'];
+    render(
+      <CategoryFilter categories={categories} selected={[]} onChange={() => {}} />
+    );
+
+    categories.forEach(category => {
+      expect(screen.getByLabelText(category)).toBeInTheDocument();
+    });
+  });
+
+  it('calls onChange with updated selection when checkboxes are clicked', () => {
+    const categories = ['Kitchen', 'Bedroom'];
+    let selected: string[] = [];
+    const handleChange = jest.fn((newSelected: string[]) => {
+      selected = newSelected;
+    });
+
+    const { rerender } = render(
+      <CategoryFilter
+        categories={categories}
+        selected={selected}
+        onChange={handleChange}
+      />
+    );
+
+    // Select Kitchen
+    fireEvent.click(screen.getByLabelText('Kitchen'));
+    expect(handleChange).toHaveBeenLastCalledWith(['Kitchen']);
+    rerender(
+      <CategoryFilter
+        categories={categories}
+        selected={selected}
+        onChange={handleChange}
+      />
+    );
+
+    // Select Bedroom
+    fireEvent.click(screen.getByLabelText('Bedroom'));
+    expect(handleChange).toHaveBeenLastCalledWith(['Kitchen', 'Bedroom']);
+    rerender(
+      <CategoryFilter
+        categories={categories}
+        selected={selected}
+        onChange={handleChange}
+      />
+    );
+
+    // Deselect Kitchen
+    fireEvent.click(screen.getByLabelText('Kitchen'));
+    expect(handleChange).toHaveBeenLastCalledWith(['Bedroom']);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for CategoryFilter rendering and selection handler

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e12b148d8832caafe5206780c6a72