### PR TITLE
test: cover server component branch of isAdminRequest

### DIFF
--- a/src/utils/__tests__/isAdminRequest.server-component.test.ts
+++ b/src/utils/__tests__/isAdminRequest.server-component.test.ts
@@ -1,0 +1,28 @@
+import { isAdminRequest } from '../adminAuth.server';
+import { cookies } from 'next/headers';
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(),
+}));
+
+describe('isAdminRequest server component', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolves true when admin cookie is present', async () => {
+    (cookies as jest.Mock).mockResolvedValue({
+      get: () => ({ value: 'true' }),
+    });
+
+    await expect(isAdminRequest()).resolves.toBe(true);
+  });
+
+  it('resolves false when admin cookie is absent', async () => {
+    (cookies as jest.Mock).mockResolvedValue({
+      get: () => undefined,
+    });
+
+    await expect(isAdminRequest()).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- test server component usage of `isAdminRequest`

## Testing
- `CI=1 npm test -- src/utils/__tests__/isAdminRequest.server-component.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689e1288cb04832ca784b35171acf180