### PR TITLE
test: add checkAdminClient helper tests

### DIFF
--- a/src/utils/__tests__/checkAdminClient.test.ts
+++ b/src/utils/__tests__/checkAdminClient.test.ts
@@ -1,0 +1,34 @@
+import { checkAdminClient } from '../adminAuth.client';
+
+describe('checkAdminClient', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  it('returns true when response ok and isAdmin true', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ isAdmin: true }),
+    } as unknown as Response);
+
+    await expect(checkAdminClient()).resolves.toBe(true);
+  });
+
+  it('returns false when response ok but isAdmin false', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ isAdmin: false }),
+    } as unknown as Response);
+
+    await expect(checkAdminClient()).resolves.toBe(false);
+  });
+
+  it('returns false when response not ok', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false } as unknown as Response);
+
+    await expect(checkAdminClient()).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `checkAdminClient` helper covering admin and non-admin responses

## Testing
- `npm test -- src/utils/__tests__/checkAdminClient.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689e14074f28832cb3d2d3c94d0e78b6