### PR TITLE
test: add add-item page test

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -46,6 +46,7 @@ const config = {
     '^@/data/(.*)$': '<rootDir>/src/data/$1',
     '^@/app/(.*)$': '<rootDir>/src/app/$1',
     '^@/lib/(.*)$': '<rootDir>/src/lib/$1',
+    '^@/utils/(.*)$': '<rootDir>/src/utils/$1',
   },
   testPathIgnorePatterns: ['<rootDir>/node_modules/', '.skip.tsx$'],
 }

--- a/src/app/registry/add-item/__tests__/page.test.tsx
+++ b/src/app/registry/add-item/__tests__/page.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// Mock the router to prevent actual navigation
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+// Mock admin auth to always resolve as true
+jest.mock('@/utils/adminAuth.client', () => ({
+  checkAdminClient: jest.fn().mockResolvedValue(true),
+}));
+
+// Mock RegistryItemForm to confirm it mounts
+jest.mock('@/components/RegistryItemForm', () => {
+  function RegistryItemForm() {
+    return <div data-testid="registry-item-form" />;
+  }
+  return RegistryItemForm;
+});
+
+import AddRegistryItemPage from '../page';
+
+describe('AddRegistryItemPage', () => {
+  it('renders the RegistryItemForm', async () => {
+    render(<AddRegistryItemPage />);
+    expect(await screen.findByTestId('registry-item-form')).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit test for registry add-item page to ensure RegistryItemForm mounts
- configure Jest to resolve `@/utils` alias

## Testing
- `npx jest src/app/registry/add-item/__tests__/page.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689e13fd9610832c8f9b0bb511744db1