### PR TITLE
Add unit test for LoadingScreen component

### DIFF
--- a/src/components/__tests__/LoadingScreen.test.tsx
+++ b/src/components/__tests__/LoadingScreen.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import LoadingScreen from '../LoadingScreen';
+
+describe('LoadingScreen', () => {
+  it('renders spinner and loading text with correct classes', () => {
+    const { container } = render(<LoadingScreen />);
+
+    const spinner = container.querySelector('svg');
+    expect(spinner).toBeInTheDocument();
+    expect(spinner).toHaveClass('animate-spin', 'h-16', 'w-16', 'text-red-500', 'mb-6');
+
+    const text = screen.getByText('Loading...');
+    expect(text).toBeInTheDocument();
+    expect(text).toHaveClass('text-xl', 'font-semibold', 'text-red-700', 'dark:text-yellow-300');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest test ensuring LoadingScreen renders spinner and Loading… text with expected classes

## Testing
- `npx jest src/components/__tests__/LoadingScreen.test.tsx`
- `npm test` *(fails: build process did not complete; see log)*

------
https://chatgpt.com/codex/tasks/task_e_689e1295f918832cbe8d975660aef974