### PR TITLE
test: ensure contributeToItem propagates update errors

### DIFF
--- a/src/services/__tests__/registryService.test.ts
+++ b/src/services/__tests__/registryService.test.ts
@@ -157,6 +157,26 @@ describe('RegistryService', () => {
       ).rejects.toThrow('Item not found');
       expect(mockUpdate).not.toHaveBeenCalled();
     });
+
+    it('propagates update failures', async () => {
+      const item = {
+        id: '1',
+        amountContributed: 0,
+        price: 100,
+        contributors: []
+      } as unknown as RegistryItem;
+      const error = new Error('Update failed');
+
+      mockTransaction.mockImplementation(async (cb: (tx: typeof prisma) => Promise<unknown>) => cb(prisma));
+      mockFindUnique.mockResolvedValue(item);
+      mockUpdate.mockRejectedValue(error);
+
+      await expect(
+        RegistryService.contributeToItem('1', { name: 'John', amount: 50 })
+      ).rejects.toThrow(error);
+      expect(mockFindUnique).toHaveBeenCalledTimes(1);
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- add regression test ensuring RegistryService.contributeToItem propagates update errors and stops further operations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e1e68e10c832c8ce930600d8b9b07