### PR TITLE
test: cover root layout admin and loading

### DIFF
--- a/src/app/__tests__/layout.test.tsx
+++ b/src/app/__tests__/layout.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import RootLayout from '../layout';
+
+const pushMock = jest.fn();
+
+jest.mock('@vercel/analytics/next', () => ({
+  Analytics: () => <div />,
+}));
+
+jest.mock('@vercel/speed-insights/next', () => ({
+  SpeedInsights: () => <div />,
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+describe('RootLayout', () => {
+  beforeEach(() => {
+    pushMock.mockClear();
+    localStorage.clear();
+  });
+
+  it('handles loading screen and admin logout', async () => {
+    const readyStateSpy = jest.spyOn(document, 'readyState', 'get').mockReturnValue('loading');
+    localStorage.setItem('isAdminLoggedIn', 'true');
+
+    render(
+      <RootLayout>
+        <div>Child content</div>
+      </RootLayout>
+    );
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+
+    expect(await screen.findByText('Admin Mode Active')).toBeInTheDocument();
+    const logoutButton = screen.getByRole('button', { name: 'Logout' });
+
+    fireEvent(window, new Event('load'));
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+
+    fireEvent.click(logoutButton);
+    expect(localStorage.getItem('isAdminLoggedIn')).toBeNull();
+    expect(pushMock).toHaveBeenCalledWith('/');
+
+    readyStateSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test ensuring RootLayout toggles LoadingScreen on window load
- verify admin bar and logout behavior clears localStorage and redirects

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e1db998dc832cba691c71c5a130a7