### PR TITLE
Handle network failures in checkAdminClient

### DIFF
--- a/src/utils/__tests__/checkAdminClient.test.ts
+++ b/src/utils/__tests__/checkAdminClient.test.ts
@@ -31,4 +31,10 @@ describe('checkAdminClient', () => {
 
     await expect(checkAdminClient()).resolves.toBe(false);
   });
+
+  it('returns false when fetch rejects', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('Network'));
+
+    await expect(checkAdminClient()).resolves.toBe(false);
+  });
 });

--- a/src/utils/adminAuth.client.ts
+++ b/src/utils/adminAuth.client.ts
@@ -8,8 +8,12 @@ export function isAdminClient(): boolean {
 
 // Or, call this API route to check admin status
 export async function checkAdminClient(): Promise<boolean> {
-  const res = await fetch('/api/admin/me');
-  if (!res.ok) return false;
-  const data = await res.json();
-  return !!data.isAdmin;
+  try {
+    const res = await fetch('/api/admin/me');
+    if (!res.ok) return false;
+    const data = await res.json();
+    return !!data.isAdmin;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary
- prevent `checkAdminClient` from throwing on network errors
- test `checkAdminClient` behavior when `fetch` rejects

## Testing
- `CI=1 npm test src/utils/__tests__/checkAdminClient.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689e1e578724832c89a8f8e03666859c