### PR TITLE
test: prevent onFinish call after unmount

### DIFF
--- a/src/components/__tests__/WeddingIntro.test.tsx
+++ b/src/components/__tests__/WeddingIntro.test.tsx
@@ -55,6 +55,21 @@ describe('WeddingIntro', () => {
     expect(onFinish).toHaveBeenCalledTimes(1);
   });
 
+  it('does not call onFinish after unmounting before the heart duration', () => {
+    const onFinish = jest.fn();
+    const { unmount } = render(<WeddingIntro onFinish={onFinish} />);
+
+    // Unmount before timers complete
+    unmount();
+
+    // Advance timers past CONFIG.HEART_DURATION * 1000 (6 seconds)
+    act(() => {
+      jest.advanceTimersByTime(6 * 1000 + 100);
+    });
+
+    expect(onFinish).not.toHaveBeenCalled();
+  });
+
   it('renders within a mocked canvas environment without crashing', () => {
     const onFinish = jest.fn();
     expect(() => render(<WeddingIntro onFinish={onFinish} />)).not.toThrow();


### PR DESCRIPTION
## Summary
- add regression test ensuring WeddingIntro's onFinish isn't called after component unmounts

## Testing
- `npm test src/components/__tests__/WeddingIntro.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689e37805fb8832ca277c4962f2ba005