### PR TITLE
test: verify isAdminRequest handles header-based auth

### DIFF
--- a/src/utils/__tests__/adminAuth.test.ts
+++ b/src/utils/__tests__/adminAuth.test.ts
@@ -41,6 +41,18 @@ describe('admin authentication helpers', () => {
       await expect(isAdminRequest(req)).resolves.toBe(true);
     });
 
+    it('returns true for request with admin header but without cookie', async () => {
+      const req = {
+        cookies: {
+          get: () => undefined,
+        },
+        headers: {
+          get: () => 'admin_auth=true',
+        },
+      } as unknown as NextRequest;
+      await expect(isAdminRequest(req)).resolves.toBe(true);
+    });
+
     it('returns false for request without admin cookie', async () => {
       const req = {
         cookies: {


### PR DESCRIPTION
## Summary
- test admin header-only requests in isAdminRequest

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e3781f468832c93efb383fd7b9a02