### PR TITLE
test: add metadata tests

### DIFF
--- a/src/app/__tests__/metadata.test.ts
+++ b/src/app/__tests__/metadata.test.ts
@@ -1,0 +1,27 @@
+import { metadata } from '../metadata';
+
+describe('metadata', () => {
+  it('matches expected values', () => {
+    expect(metadata.title).toBe("Abbigayle & Frederick's Wedding");
+    expect(metadata.description).toBe(
+      'A joyful celebration of love uniting Abbigayle & Frederick in historic Plummer House gardens.'
+    );
+    expect(metadata.icons).toEqual({ icon: '/assets/favicon.png' });
+    expect(metadata.openGraph).toEqual({
+      type: 'website',
+      url: 'https://abbifred.com/',
+      title: "Abbigayle & Frederick's Wedding",
+      description:
+        'A joyful celebration of love uniting Abbigayle & Frederick in historic Plummer House gardens.',
+      images: ['https://abbifred.com/assets/favicon.png'],
+    });
+    expect(metadata.twitter).toEqual({
+      card: 'summary',
+      title: "Abbigayle & Frederick's Wedding",
+      description:
+        'A joyful celebration of love uniting Abbigayle & Frederick in historic Plummer House gardens.',
+      images: ['https://abbifred.com/assets/favicon.png'],
+    });
+    expect(metadata.metadataBase?.href).toBe('https://abbifred.com/');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test verifying exported metadata values

## Testing
- `npm test --ignore-scripts`
- `npx jest src/app/__tests__/metadata.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689e3783e114832c906b250aa939373f