### PR TITLE
test: add theme unit tests

### DIFF
--- a/src/styles/__tests__/theme.test.ts
+++ b/src/styles/__tests__/theme.test.ts
@@ -1,0 +1,13 @@
+import theme from '../theme'
+
+describe('theme', () => {
+  it('has expected primary and secondary colors', () => {
+    expect(theme.colors.primary).toBe('#B91C1C')
+    expect(theme.colors.secondary).toBe('#B8860B')
+  })
+
+  it('defines gradients', () => {
+    expect(theme.gradients.primary).toBeDefined()
+    expect(theme.gradients.background).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary
- add tests ensuring theme colors and gradients are defined

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e3785c370832c88e48ec68078b6b4