### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/fderuiter/wedding_website/security/code-scanning/1](https://github.com/fderuiter/wedding_website/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file to explicitly restrict the `GITHUB_TOKEN` permissions. The best way to do this is to add `permissions: contents: read` at the top level of the workflow (just after the `name` and before `on`), which will apply to all jobs in the workflow unless overridden. This ensures that the workflow only has read access to repository contents, which is sufficient for typical CI tasks like building and testing. No changes to steps or jobs are required, and no additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
