### PR TITLE
fix(api): Correct properties for RegistryService.createItem

### DIFF
--- a/src/app/api/registry/add-item/route.ts
+++ b/src/app/api/registry/add-item/route.ts
@@ -26,9 +26,7 @@ export async function POST(request: Request) {
       vendorUrl: newItemData.vendorUrl || null,
       quantity: Number(newItemData.quantity),
       isGroupGift: newItemData.isGroupGift || false,
-      purchased: false,
       purchaserName: null,
-      amountContributed: 0,
     });
 
     return NextResponse.json({ message: 'Item added successfully', item: newItem }, { status: 201 });


### PR DESCRIPTION
Removes `purchased` and `amountContributed` from the object passed to `RegistryService.createItem` in the `add-item` API route. These properties are not expected by the `createItem` function, as they are managed by the database, and their inclusion was causing a TypeScript compilation error.

---
name: Pull Request
about: Describe your changes to help the reviewer.
title: ""
labels: ''
assignees: ''

---

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (change to documentation pages)
- [ ] Other (please describe):

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

(If this PR contains a breaking change, please describe the impact and migration path for existing applications below.)

**Other information**:
