### PR TITLE
feat: Add Wedding Party page

### DIFF
--- a/src/app/wedding-party/page.tsx
+++ b/src/app/wedding-party/page.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Metadata } from 'next';
+import WeddingPartyList from '@/components/WeddingPartyList';
+
+export const metadata: Metadata = {
+  title: "Wedding Party",
+  alternates: {
+    canonical: '/wedding-party',
+  },
+};
+
+export default function WeddingPartyPage() {
+  return (
+    <main className="container mx-auto px-4 py-8">
+      <h1 className="text-4xl font-bold text-center mb-8 text-rose-700 dark:text-rose-400">
+        Wedding Party
+      </h1>
+      <WeddingPartyList />
+    </main>
+  );
+}

--- a/src/components/WeddingPartyCard.tsx
+++ b/src/components/WeddingPartyCard.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import Image from 'next/image';
+import { WeddingPartyMember } from '@/data/wedding-party';
+import { ExternalLink } from 'lucide-react';
+
+interface WeddingPartyCardProps {
+  member: WeddingPartyMember;
+}
+
+const WeddingPartyCard: React.FC<WeddingPartyCardProps> = ({ member }) => {
+  return (
+    <div className="bg-white dark:bg-gray-800 shadow-lg rounded-lg overflow-hidden transform transition-transform hover:scale-105">
+      <div className="relative h-64 w-full">
+        <Image
+          src={member.photo}
+          alt={`Photo of ${member.name}`}
+          fill
+          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+          style={{ objectFit: 'cover' }}
+          className="rounded-t-lg"
+        />
+      </div>
+      <div className="p-6">
+        <h3 className="text-2xl font-bold text-rose-700 dark:text-rose-400 mb-2">{member.name}</h3>
+        <p className="text-lg font-medium text-gray-600 dark:text-gray-300 mb-4">{member.role}</p>
+        <p className="text-base text-gray-700 dark:text-gray-400 mb-4">{member.bio}</p>
+        {member.link && (
+          <a
+            href={member.link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center text-rose-600 dark:text-rose-400 hover:text-rose-800 dark:hover:text-rose-200"
+          >
+            Learn more <ExternalLink className="ml-2 h-4 w-4" />
+          </a>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default WeddingPartyCard;

--- a/src/components/WeddingPartyList.tsx
+++ b/src/components/WeddingPartyList.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import React from 'react';
+import { weddingPartyMembers } from '@/data/wedding-party';
+import WeddingPartyCard from './WeddingPartyCard';
+
+const WeddingPartyList: React.FC = () => {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+      {weddingPartyMembers.map((member) => (
+        <WeddingPartyCard key={member.name} member={member} />
+      ))}
+    </div>
+  );
+};
+
+export default WeddingPartyList;

--- a/src/components/layout/RootLayoutClient.tsx
+++ b/src/components/layout/RootLayoutClient.tsx
@@ -14,6 +14,7 @@ const queryClient = new QueryClient();
 const navLinks = [
   { href: '/', label: 'Home' },
   { href: '/photos', label: 'Photos' },
+  { href: '/wedding-party', label: 'Wedding Party' },
   { href: '/things-to-do', label: 'Things to Do' },
 ];
 

--- a/src/data/wedding-party.ts
+++ b/src/data/wedding-party.ts
@@ -1,0 +1,34 @@
+export interface WeddingPartyMember {
+  name: string;
+  role: string;
+  bio: string;
+  photo: string;
+  link?: string;
+}
+
+export const weddingPartyMembers: WeddingPartyMember[] = [
+  {
+    name: 'Jane Doe',
+    role: 'Maid of Honor',
+    bio: 'Jane has been a friend of the bride since college. They share a love for hiking and bad movies.',
+    photo: '/images/placeholder.png',
+  },
+  {
+    name: 'John Smith',
+    role: 'Best Man',
+    bio: 'John and the groom have been friends since childhood. They grew up playing video games together.',
+    photo: '/images/placeholder.png',
+  },
+  {
+    name: 'Emily Jones',
+    role: 'Bridesmaid',
+    bio: 'Emily and the bride met through a local book club and quickly bonded over their love for fantasy novels.',
+    photo: '/images/placeholder.png',
+  },
+  {
+    name: 'Michael Johnson',
+    role: 'Groomsman',
+    bio: 'Michael is the groom\'s brother and partner in crime. They enjoy fishing and camping together.',
+    photo: '/images/placeholder.png',
+  },
+];


### PR DESCRIPTION
Adds a new 'Wedding Party' page to the website, accessible at the `/wedding-party` route.

The new page displays a list of wedding party members in a responsive, card-based layout. Each card includes a photo, name, role, and a short bio for the member.

The content for the wedding party members is managed through a data file at `src/data/wedding-party.ts`, making it easy to edit and update.

A link to the new page has also been added to the main navigation menu.