### PR TITLE
feat: Show intro animation only on first visit

### DIFF
--- a/src/components/home/HomePageClient.tsx
+++ b/src/components/home/HomePageClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import dynamic from 'next/dynamic'
 import { motion } from 'framer-motion'
 import { ChevronDown } from 'lucide-react'
@@ -16,11 +16,28 @@ const WeddingIntro = dynamic<{ onFinish?: () => void }>(() => import('@/componen
 const fadeUp = { hidden: { opacity: 0, y: 40 }, visible: (i: number) => ({ opacity: 1, y: 0, transition: { delay: 0.15 * i, duration: 0.8 } }) }
 
 export default function HomePageClient({ galleryImages, calendarEvent }: { galleryImages: GalleryImage[], calendarEvent: CalendarEvent }) {
-  const [introFinished, setIntroFinished] = useState(false);
+  const [hasVisited, setHasVisited] = useState<boolean | null>(null);
+  const [introPlayed, setIntroPlayed] = useState(false);
+
+  useEffect(() => {
+    const visited = localStorage.getItem('hasVisited');
+    if (visited) {
+      setHasVisited(true);
+    } else {
+      localStorage.setItem('hasVisited', 'true');
+      setHasVisited(false);
+    }
+  }, []);
+
+  const introFinished = hasVisited || introPlayed;
+
+  if (hasVisited === null) {
+    return null; // Or a loading spinner
+  }
 
   return (
     <>
-      {!introFinished && <WeddingIntro onFinish={() => setIntroFinished(true)} />}
+      {!introFinished && <WeddingIntro onFinish={() => setIntroPlayed(true)} />}
       <div id="top" />
       <div className={`min-h-screen bg-[var(--color-background)] text-[var(--color-foreground)] selection:bg-rose-100 selection:text-rose-900 dark:selection:bg-rose-800 ${!introFinished ? 'hidden' : ''}`}
       >


### PR DESCRIPTION
Modified the HomePageClient component to only show the wedding intro animation the first time a user visits the page.

- Uses localStorage to track whether a user has visited before.
- Prevents the animation from showing on subsequent visits.
- Implemented a solution to prevent a flicker effect on page load for returning visitors.

---
name: Pull Request
about: Describe your changes to help the reviewer.
title: ""
labels: ''
assignees: ''

---

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (change to documentation pages)
- [ ] Other (please describe):

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

(If this PR contains a breaking change, please describe the impact and migration path for existing applications below.)

**Other information**:
