### PR TITLE
feat: Remove photo gallery from homepage

### DIFF
--- a/src/app/__tests__/home.test.tsx
+++ b/src/app/__tests__/home.test.tsx
@@ -30,11 +30,6 @@ jest.mock('@/components/WeddingIntro', () => {
   };
 });
 
-jest.mock('@/components/Gallery', () => ({
-  __esModule: true,
-  default: () => <div data-testid="gallery" />,
-}));
-
 jest.mock('@/components/AddToCalendar', () => ({
   __esModule: true,
   default: () => <button>Add to Calendar</button>,
@@ -51,7 +46,6 @@ describe('Home Page', () => {
     await screen.findAllByRole('button', { name: 'Add to Calendar' });
 
     // Gallery and hero heading render
-    expect(screen.getAllByTestId('gallery').length).toBeGreaterThan(0);
     expect(screen.getByRole('heading', { name: /Abbi.*Fred/ })).toBeInTheDocument();
 
     expect(screen.getByRole('link', { name: 'Our Story' })).toBeInTheDocument();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Metadata } from 'next';
 import HomePageClient from '@/components/home/HomePageClient';
 import { CalendarEvent } from '@/components/AddToCalendar';
-import { GalleryImage } from '@/components/Gallery';
 
 const jsonLd = {
   '@context': 'https://schema.org',
@@ -49,16 +48,6 @@ const calendarEvent: CalendarEvent = {
   description: jsonLd.description,
 };
 
-const galleryImages: GalleryImage[] = [
-  { src: '/images/sunset-embrace.jpg', alt: 'Abbi and Fred hug on a lakeside path at sunset, framed by twisting bare branches and a glowing orange sky.' },
-  { src: '/images/jogging-buddies.jpg', alt: 'Sweaty but smiling, Abbi and Fred snap a post-run selfie on a sunny sidewalk beside a brick building.' },
-  { src: '/images/winter-warmth.jpg', alt: 'Bundled in winter layers, Abbi and Fred pose against a brick wall—she in leopard-trimmed coat and hat, he in a dark jacket—both beaming.' },
-  { src: '/images/sunset-kiss.jpg', alt: 'Abbi and Fred share a quiet kiss at sunset beneath leafless tree silhouettes, golden light reflecting off the lake behind them.' },
-  { src: '/images/timberwolves.jpg', alt: 'Abbi and Fred smile from their seats at a packed Timberwolves basketball game, sporting team gear and surrounded by excited fans.' },
-  { src: '/images/twins-wins.jpg', alt: 'Abbi and Fred grin for a selfie with Target\u202fField and a cheering Minnesota Twins crowd spread out behind them.' },
-  { src: '/images/post-graduation-celebration.jpg', alt: 'Dressed up for the evening, Fred in a crisp white shirt hugs Abbi in a black dress as they smile warmly against a simple light backdrop.' },
-];
-
 export default function HomePage() {
-  return <HomePageClient galleryImages={galleryImages} calendarEvent={calendarEvent} />;
+  return <HomePageClient calendarEvent={calendarEvent} />;
 }

--- a/src/components/home/HomePageClient.tsx
+++ b/src/components/home/HomePageClient.tsx
@@ -6,7 +6,6 @@ import { motion } from 'framer-motion'
 import { ChevronDown } from 'lucide-react'
 import AddToCalendar, { CalendarEvent } from '@/components/AddToCalendar'
 import Link from 'next/link'
-import Gallery, { GalleryImage } from '@/components/Gallery'
 import BackToTop from '@/components/BackToTop'
 import Countdown from '@/components/Countdown'
 
@@ -15,7 +14,7 @@ const WeddingIntro = dynamic<{ onFinish?: () => void }>(() => import('@/componen
 
 const fadeUp = { hidden: { opacity: 0, y: 40 }, visible: (i: number) => ({ opacity: 1, y: 0, transition: { delay: 0.15 * i, duration: 0.8 } }) }
 
-export default function HomePageClient({ galleryImages, calendarEvent }: { galleryImages: GalleryImage[], calendarEvent: CalendarEvent }) {
+export default function HomePageClient({ calendarEvent }: { calendarEvent: CalendarEvent }) {
   const [hasVisited, setHasVisited] = useState<boolean | null>(null);
   const [introPlayed, setIntroPlayed] = useState(false);
 
@@ -44,9 +43,6 @@ export default function HomePageClient({ galleryImages, calendarEvent }: { galle
         <main id="main">
           <section className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden px-4 py-28 text-center sm:px-6 lg:px-8">
             <motion.div className="absolute inset-0 -z-10 bg-[radial-gradient(800px_circle_at_50%_50%,rgba(190,18,60,0.06),transparent)]" animate={{ scale: [1, 1.04, 1], opacity: [0.7, 0.5, 0.7] }} transition={{ duration: 14, repeat: Infinity, repeatType: 'reverse' }} />
-            <motion.div className="mb-8" variants={fadeUp} initial="hidden" animate="visible" custom={-1}>
-              <Gallery images={galleryImages} />
-            </motion.div>
             <motion.h1 className="mb-6 text-5xl font-extrabold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-rose-700 to-amber-500 sm:text-6xl lg:text-7xl" variants={fadeUp} initial="hidden" animate="visible" custom={0}>
               Abbigayle &amp; Frederick&apos;s Wedding
             </motion.h1>
@@ -123,9 +119,6 @@ export default function HomePageClient({ galleryImages, calendarEvent }: { galle
                 <p>Yes, there are 40 spots of parking available at the Plummer House.</p>
               </div>
             </div>
-          </motion.section>
-          <motion.section className="py-10" initial="hidden" whileInView="visible" viewport={{ once: true }} variants={fadeUp} custom={2.1}>
-            <Gallery images={galleryImages} />
           </motion.section>
           <footer className="flex flex-col items-center gap-4 px-4 pb-10 text-sm text-gray-500 dark:text-gray-400">
             <p>© {new Date().getFullYear()} Abbigayle & Frederick • Designed with ❤️ in Minnesota</p>


### PR DESCRIPTION
This commit removes the photo gallery from the homepage. The gallery was displayed at the top and bottom of the page.

The following changes were made:
- Removed the `Gallery` component from `src/components/home/HomePageClient.tsx`.
- Removed the `galleryImages` prop from `src/app/page.tsx`.
- Updated the test in `src/app/__tests__/home.test.tsx` to no longer expect the gallery to be present.
