### PR TITLE
feat: Add reset button to heart page

### DIFF
--- a/src/app/heart/page.tsx
+++ b/src/app/heart/page.tsx
@@ -211,6 +211,12 @@ function ScreenBounds() {
 export default function HeartPage() {
   const [interacted, setInteracted] = useState(false)
   const [scale, setScale] = useState(0.6)
+  const [resetKey, setResetKey] = useState(0)
+
+  const handleReset = () => {
+    setInteracted(false)
+    setResetKey((prevKey) => prevKey + 1)
+  }
 
   useEffect(() => {
     const handleResize = () => {
@@ -225,14 +231,23 @@ export default function HeartPage() {
 
   return (
     <div className="fixed inset-0 bg-black select-none">
-      <Link href="/" className="absolute top-0 right-0 z-10 m-4 rounded bg-white/80 px-3 py-1 text-sm hover:bg-white">
-        Back Home
-      </Link>
+      <div className="absolute top-0 right-0 z-[60] m-4 flex gap-2">
+        <button
+          onClick={handleReset}
+          className="rounded bg-white/80 px-3 py-1 text-sm hover:bg-white"
+          aria-label="Reset heart"
+        >
+          Reset
+        </button>
+        <Link href="/" className="rounded bg-white/80 px-3 py-1 text-sm hover:bg-white">
+          Back Home
+        </Link>
+      </div>
       <Canvas camera={{ position: [0, 0, 15], fov: 50 }} dpr={[1, 2]}>
         <ambientLight intensity={0.8} />
         <directionalLight position={[5, 8, 5]} intensity={1.6} />
         <Suspense fallback={<Html>Loading…</Html>}>
-          <Physics gravity={[0, 0, 0]}>
+          <Physics key={resetKey} gravity={[0, 0, 0]}>
             <Sparkles />
             <Environment preset="sunset" />
             <PhysicsHeart scale={scale} interacted={interacted} onInteract={() => setInteracted(true)} />

--- a/src/components/layout/RootLayoutClient.tsx
+++ b/src/components/layout/RootLayoutClient.tsx
@@ -61,8 +61,9 @@ export default function RootLayoutClient({
     resizeObserver.observe(headerRef.current);
 
     return () => resizeObserver.disconnect();
-  }, []);
+  }, [pathname]);
 
+  const isHeartPage = pathname === '/heart';
 
   const handleLogout = () => {
     localStorage.removeItem('isAdminLoggedIn');
@@ -72,45 +73,47 @@ export default function RootLayoutClient({
 
   return (
     <QueryClientProvider client={queryClient}>
-      <header
-        ref={headerRef}
-        className="bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 text-center text-sm flex flex-col items-stretch fixed top-0 w-full z-50 border-b border-gray-200 dark:border-gray-700"
-      >
-        <div className="p-4 flex justify-between items-center w-full">
-          <nav>
-            <ul className="flex gap-4">
-              {navLinks.map((link) => (
-                <li key={link.href}>
-                  <Link href={link.href} className="hover:text-rose-400">
-                    {link.label}
-                  </Link>
-                </li>
-              ))}
-              {pathname === '/' &&
-                homeNavLinks.map((link) => (
+      {!isHeartPage && (
+        <header
+          ref={headerRef}
+          className="bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 text-center text-sm flex flex-col items-stretch fixed top-0 w-full z-50 border-b border-gray-200 dark:border-gray-700"
+        >
+          <div className="p-4 flex justify-between items-center w-full">
+            <nav>
+              <ul className="flex gap-4">
+                {navLinks.map((link) => (
                   <li key={link.href}>
                     <Link href={link.href} className="hover:text-rose-400">
                       {link.label}
                     </Link>
                   </li>
                 ))}
-            </ul>
-          </nav>
-          {isAdmin && (
-            <div className="flex items-center gap-4">
-              <span>Admin Mode Active</span>
-              <button
-                onClick={handleLogout}
-                className="bg-rose-600 hover:bg-rose-700 text-white text-xs py-1 px-3 rounded-md"
-              >
-                Logout
-              </button>
-            </div>
-          )}
-        </div>
-        <TravelStrip />
-      </header>
-      <main id="main-content" style={{ paddingTop: mainPaddingTop }}>
+                {pathname === '/' &&
+                  homeNavLinks.map((link) => (
+                    <li key={link.href}>
+                      <Link href={link.href} className="hover:text-rose-400">
+                        {link.label}
+                      </Link>
+                    </li>
+                  ))}
+              </ul>
+            </nav>
+            {isAdmin && (
+              <div className="flex items-center gap-4">
+                <span>Admin Mode Active</span>
+                <button
+                  onClick={handleLogout}
+                  className="bg-rose-600 hover:bg-rose-700 text-white text-xs py-1 px-3 rounded-md"
+                >
+                  Logout
+                </button>
+              </div>
+            )}
+          </div>
+          <TravelStrip />
+        </header>
+      )}
+      <main id="main-content" style={{ paddingTop: isHeartPage ? 0 : mainPaddingTop }}>
         {children}
       </main>
       <SpeedInsights />


### PR DESCRIPTION
This commit introduces a reset button on the "/heart" page.

The button allows users to reset the interactive 3D heart animation to its initial state. This is achieved by forcing a re-mount of the physics simulation component when the button is clicked.

Additionally, the main site header is now hidden on the "/heart" page to provide a more immersive, full-screen experience and prevent UI conflicts with the page's controls.