### PR TITLE
Update wedding party information

### DIFF
--- a/src/data/wedding-party.ts
+++ b/src/data/wedding-party.ts
@@ -8,27 +8,51 @@ export interface WeddingPartyMember {
 
 export const weddingPartyMembers: WeddingPartyMember[] = [
   {
-    name: 'Jane Doe',
+    name: 'Emily Schultz',
     role: 'Maid of Honor',
-    bio: 'Jane has been a friend of the bride since college. They share a love for hiking and bad movies.',
+    bio: 'Sister of the Bride',
     photo: '/images/placeholder.png',
   },
   {
-    name: 'John Smith',
-    role: 'Best Man',
-    bio: 'John and the groom have been friends since childhood. They grew up playing video games together.',
-    photo: '/images/placeholder.png',
-  },
-  {
-    name: 'Emily Jones',
+    name: 'Callie Sebora',
     role: 'Bridesmaid',
-    bio: 'Emily and the bride met through a local book club and quickly bonded over their love for fantasy novels.',
+    bio: 'Sister of the Bride',
     photo: '/images/placeholder.png',
   },
   {
-    name: 'Michael Johnson',
+    name: 'Isabella de Ruiter',
+    role: 'Bridesmaid',
+    bio: 'Sister of the Groom',
+    photo: '/images/placeholder.png',
+  },
+  {
+    name: 'Delaney Sebora',
+    role: 'Bridesmaid',
+    bio: 'Sister of the Bride',
+    photo: '/images/placeholder.png',
+  },
+  {
+    name: 'Vincent de Ruiter',
+    role: 'Best Man',
+    bio: 'Brother of the Groom',
+    photo: '/images/placeholder.png',
+  },
+  {
+    name: 'Peter de Ruiter',
     role: 'Groomsman',
-    bio: 'Michael is the groom\'s brother and partner in crime. They enjoy fishing and camping together.',
+    bio: 'Brother of the groom',
+    photo: '/images/placeholder.png',
+  },
+  {
+    name: 'Caleb Sebora',
+    role: 'Groomsman',
+    bio: 'Brother of the Bride',
+    photo: '/images/placeholder.png',
+  },
+  {
+    name: 'Ethan Schultz',
+    role: 'Groomsman',
+    bio: 'Brother of the Bride',
     photo: '/images/placeholder.png',
   },
 ];


### PR DESCRIPTION
This pull request updates the `weddingPartyMembers` array in `src/data/wedding-party.ts` to reflect a new set of wedding party members, replacing the previous placeholder entries with actual family members and their roles. The changes ensure that the data now accurately represents the bride's and groom's siblings and their roles in the wedding.

Updates to wedding party members:

* Replaced previous placeholder members (e.g., Jane Doe, John Smith, Emily Jones, Michael Johnson) with actual family members, including siblings of the bride and groom, and updated their roles and bios accordingly.
* Added several new members to the array, such as Delaney Sebora, Vincent de Ruiter, Peter de Ruiter, and Caleb Sebora, specifying their roles and relationships to the couple.