### PR TITLE
feat: Prevent over-contribution to registry items

### DIFF
--- a/src/services/__tests__/registryService.test.ts
+++ b/src/services/__tests__/registryService.test.ts
@@ -177,6 +177,23 @@ describe('RegistryService', () => {
       expect(mockFindUnique).toHaveBeenCalledTimes(1);
       expect(mockUpdate).toHaveBeenCalledTimes(1);
     });
+
+    it('throws when contribution is greater than remaining amount', async () => {
+      const item = {
+        id: '1',
+        amountContributed: 80,
+        price: 100,
+        contributors: []
+      } as unknown as RegistryItem;
+
+      mockTransaction.mockImplementation(async (cb: (tx: typeof prisma) => Promise<unknown>) => cb(prisma));
+      mockFindUnique.mockResolvedValue(item);
+
+      await expect(
+        RegistryService.contributeToItem('1', { name: 'John', amount: 50 })
+      ).rejects.toThrow('Contribution cannot be greater than the remaining amount.');
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/src/services/registryService.ts
+++ b/src/services/registryService.ts
@@ -104,6 +104,11 @@ export class RegistryService {
         throw new Error('Item not found');
       }
 
+      const remainingAmount = item.price - item.amountContributed;
+      if (contribution.amount > remainingAmount) {
+        throw new Error('Contribution cannot be greater than the remaining amount.');
+      }
+
       const newTotal = item.amountContributed + contribution.amount;
       
       // Update the item's total contribution and add the new contributor.


### PR DESCRIPTION
Adds a validation check to the `contributeToItem` service function.

This change prevents a user from contributing an amount that is greater than the remaining balance on a registry item. Previously, it was possible for the total contributions to exceed the item's price.

A new unit test has been added to verify that an error is thrown when an over-contribution is attempted.

---
name: Pull Request
about: Describe your changes to help the reviewer.
title: ""
labels: ''
assignees: ''

---

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (change to documentation pages)
- [ ] Other (please describe):

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

(If this PR contains a breaking change, please describe the impact and migration path for existing applications below.)

**Other information**:
