### PR TITLE
Fix: Standardize on 'name' for contribution validation

### DIFF
--- a/src/app/api/__tests__/registryRoutes.test.ts
+++ b/src/app/api/__tests__/registryRoutes.test.ts
@@ -100,7 +100,7 @@ describe('Registry API routes', () => {
   describe('POST /api/registry/contribute', () => {
     const validContribution = {
       itemId: '1',
-      purchaserName: 'John',
+      name: 'John',
       amount: 25,
     };
 
@@ -113,7 +113,7 @@ describe('Registry API routes', () => {
       const res = await contribute(req);
       expect(res.status).toBe(200);
       expect(mockContributeToItem).toHaveBeenCalledWith(validContribution.itemId, {
-        name: validContribution.purchaserName,
+        name: validContribution.name,
         amount: validContribution.amount,
       });
     });
@@ -121,7 +121,7 @@ describe('Registry API routes', () => {
     it('returns 400 for invalid data', async () => {
       const req = new Request('http://localhost/api/registry/contribute', {
         method: 'POST',
-        body: JSON.stringify({ purchaserName: '', amount: -5 }),
+        body: JSON.stringify({ name: '', amount: -5 }),
       });
       const res = await contribute(req);
       expect(res.status).toBe(400);

--- a/src/app/api/registry/contribute/route.ts
+++ b/src/app/api/registry/contribute/route.ts
@@ -25,10 +25,10 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: validationError }, { status: 400 });
     }
 
-    const { itemId, purchaserName, amount } = data;
+    const { itemId, name, amount } = data;
 
     const updatedItem = await RegistryService.contributeToItem(itemId, {
-      name: purchaserName,
+      name,
       amount: Number(amount)
     });
 

--- a/src/utils/__tests__/validation.test.ts
+++ b/src/utils/__tests__/validation.test.ts
@@ -3,8 +3,8 @@ import { validateContributeInput, validateAddItemInput } from '../validation';
 describe('validateContributeInput', () => {
   const cases: Array<{ name: string; input: unknown; expected: string | null }> = [
     {
-      name: 'valid payload',
-      input: { itemId: '1', purchaserName: 'Alice', amount: 100 },
+      name: 'valid payload for group gift contribution',
+      input: { itemId: '1', name: 'Alice', amount: 100 },
       expected: null,
     },
     {
@@ -14,19 +14,24 @@ describe('validateContributeInput', () => {
     },
     {
       name: 'missing itemId',
-      input: { purchaserName: 'Alice', amount: 100 },
+      input: { name: 'Alice', amount: 100 },
       expected: 'Missing or invalid itemId.',
     },
     {
-      name: 'missing purchaserName',
+      name: 'missing name',
       input: { itemId: '1', amount: 100 },
       expected: 'Name is required.',
     },
     {
       name: 'invalid amount',
-      input: { itemId: '1', purchaserName: 'Alice', amount: -5 },
+      input: { itemId: '1', name: 'Alice', amount: -5 },
       expected: 'Contribution amount must be a positive number.',
     },
+    {
+      name: 'empty name',
+      input: { itemId: '1', name: '  ', amount: 100 },
+      expected: 'Name is required.',
+    }
   ];
 
   test.each(cases)('$name', ({ input, expected }) => {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -10,7 +10,7 @@ export function validateContributeInput(input: unknown): string | null { // Chan
   // Use type assertion or type guards for property access
   const data = input as Record<string, unknown>;
   if (!data.itemId || typeof data.itemId !== 'string') return 'Missing or invalid itemId.';
-  if (!data.purchaserName || typeof data.purchaserName !== 'string' || String(data.purchaserName).trim().length === 0) return 'Name is required.';
+  if (!data.name || typeof data.name !== 'string' || String(data.name).trim().length === 0) return 'Name is required.';
   if (typeof data.amount !== 'number' || isNaN(data.amount) || data.amount <= 0) return 'Contribution amount must be a positive number.';
   return null;
 }


### PR DESCRIPTION
The validation for the contribution endpoint was incorrectly checking for `purchaserName` instead of `name`. This was inconsistent with the service layer and the likely frontend implementation for group gifts.

This commit standardizes the contribution flow to use `name` for the contributor's name.

- Updates `validateContributeInput` to check for `name`.
- Updates the `contribute` API route to destructure `name` from the request body.
- Updates the corresponding tests to use `name` in the payload, ensuring they align with the corrected logic.

---
name: Pull Request
about: Describe your changes to help the reviewer.
title: ""
labels: ''
assignees: ''

---

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (change to documentation pages)
- [ ] Other (please describe):

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

(If this PR contains a breaking change, please describe the impact and migration path for existing applications below.)

**Other information**:
