### PR TITLE
fix(registry): Prevent negative contributions to registry items

### DIFF
--- a/src/features/registry/service.ts
+++ b/src/features/registry/service.ts
@@ -61,6 +61,10 @@ export class RegistryService {
     itemId: string,
     contribution: { name: string; amount: number }
   ) {
+    if (contribution.amount <= 0) {
+      throw new Error('Contribution must be a positive number.');
+    }
+
     const item = await RegistryRepository.getItemById(itemId);
 
     if (!item) {


### PR DESCRIPTION
Adds a validation check to the `contributeToItem` method in the `RegistryService` to ensure that the contribution amount is a positive number. This prevents users from making negative or zero contributions, which could lead to data inconsistencies.