### PR TITLE
feat: Improve test coverage for various components and pages

### DIFF
--- a/src/app/__tests__/sitemap.test.ts
+++ b/src/app/__tests__/sitemap.test.ts
@@ -1,0 +1,31 @@
+import sitemap from '../sitemap';
+
+describe('sitemap', () => {
+  it('should return the correct sitemap entries', () => {
+    const sitemapEntries = sitemap();
+    const siteUrl = 'https://abbifred.com';
+
+    expect(sitemapEntries).toHaveLength(3);
+
+    expect(sitemapEntries).toContainEqual({
+      url: `${siteUrl}/`,
+      lastModified: expect.any(Date),
+      changeFrequency: 'yearly',
+      priority: 1,
+    });
+
+    expect(sitemapEntries).toContainEqual({
+      url: `${siteUrl}/project-info`,
+      lastModified: expect.any(Date),
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    });
+
+    expect(sitemapEntries).toContainEqual({
+      url: `${siteUrl}/heart`,
+      lastModified: expect.any(Date),
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    });
+  });
+});

--- a/src/app/heart/__tests__/page.test.tsx
+++ b/src/app/heart/__tests__/page.test.tsx
@@ -3,7 +3,9 @@ import { render, screen, fireEvent, act } from '@testing-library/react';
 import HeartPage from '../page';
 import { RigidBodyType } from '@dimforge/rapier3d-compat';
 
-let onContactForceCallback: (payload: any) => void;
+import { ContactForceEvent } from '@react-three/rapier';
+
+let onContactForceCallback: (payload: ContactForceEvent) => void;
 
 const mockRigidBodyApi = {
     setBodyType: jest.fn(),
@@ -48,9 +50,9 @@ jest.mock('@react-three/postprocessing', () => ({
 }));
 
 jest.mock('@react-three/rapier', () => {
-    const RigidBodyMock = React.forwardRef(({ children, onContactForce }: any, ref) => {
+    const RigidBodyMock = React.forwardRef(({ children, onContactForce }: { children: React.ReactNode, onContactForce: (payload: ContactForceEvent) => void }, ref: React.Ref<unknown>) => {
         if (ref) {
-            // @ts-ignore
+            // @ts-expect-error This is a mock implementation
             ref.current = mockRigidBodyApi;
         }
         if (onContactForce) {
@@ -104,9 +106,11 @@ jest.mock('@use-gesture/react', () => ({
 
 
 jest.mock('next/link', () => {
-    return ({ children, href }: { children: React.ReactNode, href: string }) => {
-        return <a href={href}>{children}</a>
-    }
+    const MockLink = ({ children, href }: { children: React.ReactNode, href: string }) => {
+        return <a href={href}>{children}</a>;
+    };
+    MockLink.displayName = 'MockLink';
+    return MockLink;
 })
 
 // Mock three.js because JSDOM doesn't have a canvas

--- a/src/app/heart/__tests__/page.test.tsx
+++ b/src/app/heart/__tests__/page.test.tsx
@@ -1,0 +1,212 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import HeartPage from '../page';
+import { RigidBodyType } from '@dimforge/rapier3d-compat';
+
+let onContactForceCallback: (payload: any) => void;
+
+const mockRigidBodyApi = {
+    setBodyType: jest.fn(),
+    setTranslation: jest.fn(),
+    setRotation: jest.fn(),
+    setLinvel: jest.fn(),
+    setAngvel: jest.fn(),
+    applyImpulse: jest.fn(),
+    applyTorqueImpulse: jest.fn(),
+    translation: jest.fn(() => ({ x: 0, y: 0, z: 0 })),
+    rotation: jest.fn(() => ({ x: 0, y: 0, z: 0, w: 1 })),
+    linvel: jest.fn(() => ({ x: 0, y: 0, z: 0 })),
+    angvel: jest.fn(() => ({ x: 0, y: 0, z: 0 })),
+    setNextKinematicTranslation: jest.fn(),
+    addForce: jest.fn(),
+};
+
+jest.mock('@react-three/fiber', () => ({
+  Canvas: ({ children }: { children: React.ReactNode }) => <div data-testid="canvas">{children}</div>,
+  useFrame: jest.fn(),
+  useThree: jest.fn(() => ({
+    size: { width: 800, height: 600 },
+    viewport: { width: 10, height: 7.5 },
+  })),
+}));
+
+jest.mock('@react-three/drei', () => ({
+    Environment: () => null,
+    Html: ({ children }: { children: React.ReactNode }) => <div data-testid="html">{children}</div>,
+    Text: ({ children }: { children: React.ReactNode }) => <div data-testid="text">{children}</div>,
+    Points: ({ children, positions }: { children: React.ReactNode, positions: Float32Array }) => (
+        <div data-testid="points" data-positions-length={positions ? positions.length : 0}>
+            {children}
+        </div>
+    ),
+    PointMaterial: () => null,
+}));
+
+jest.mock('@react-three/postprocessing', () => ({
+  EffectComposer: ({ children }: { children: React.ReactNode }) => <div data-testid="effect-composer">{children}</div>,
+  Bloom: () => null,
+}));
+
+jest.mock('@react-three/rapier', () => {
+    const RigidBodyMock = React.forwardRef(({ children, onContactForce }: any, ref) => {
+        if (ref) {
+            // @ts-ignore
+            ref.current = mockRigidBodyApi;
+        }
+        if (onContactForce) {
+            onContactForceCallback = onContactForce;
+        }
+        return <div data-testid="rigidbody">{children}</div>;
+    });
+    RigidBodyMock.displayName = 'RigidBody';
+
+    return {
+        Physics: ({ children }: { children: React.ReactNode }) => <div data-testid="physics">{children}</div>,
+        RigidBody: RigidBodyMock,
+        CuboidCollider: () => <div data-testid="cuboid-collider" />,
+        RapierRigidBody: jest.fn(),
+        CuboidColliderProps: jest.fn(),
+        ActiveCollisionTypes: {
+            CONTACT_FORCE_EVENTS: 0,
+        },
+        RigidBodyType: {
+            Dynamic: 0,
+            Fixed: 1,
+            KinematicPositionBased: 2,
+        }
+    }
+});
+
+jest.mock('maath/random', () => ({
+  inSphere: jest.fn((buffer, { radius }) => {
+    if(!buffer) return new Float32Array(0);
+    const count = buffer.length / 3;
+    const newBuffer = new Float32Array(count * 3);
+    for (let i = 0; i < count * 3; i++) {
+        newBuffer[i] = (Math.random() - 0.5) * 2 * radius;
+    }
+    return newBuffer;
+  }),
+}));
+
+jest.mock('@use-gesture/react', () => ({
+  useDrag: jest.fn((callback) => {
+    return () => ({
+      onMouseDown: (event: React.MouseEvent) => {
+        callback({ active: true, xy: [event.clientX, event.clientY], velocity: [0,0], first: true, last: false });
+      },
+      onMouseUp: (event: React.MouseEvent) => {
+        callback({ active: false, xy: [event.clientX, event.clientY], velocity: [1,1], first: false, last: true });
+      }
+    });
+  }),
+}));
+
+
+jest.mock('next/link', () => {
+    return ({ children, href }: { children: React.ReactNode, href: string }) => {
+        return <a href={href}>{children}</a>
+    }
+})
+
+// Mock three.js because JSDOM doesn't have a canvas
+jest.mock('three', () => {
+  const THREE = jest.requireActual('three');
+  return {
+    ...THREE,
+    Shape: class {
+      moveTo() {}
+      bezierCurveTo() {}
+    },
+    ExtrudeGeometry: class {
+      center() {}
+    },
+    Plane: class {},
+    Vector3: class {},
+    MeshPhysicalMaterial: class {},
+    Euler: class {
+      setFromQuaternion() { return this; }
+    },
+    Quaternion: class {
+      setFromEuler() {}
+    },
+  };
+});
+
+describe('HeartPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const useThree = jest.requireMock('@react-three/fiber').useThree;
+    useThree.mockReturnValue({
+      size: { width: 800, height: 600 },
+      viewport: { width: 10, height: 7.5 },
+    });
+  });
+
+  it('renders the page without crashing', () => {
+    render(<HeartPage />);
+    expect(screen.getByText('Back Home')).toBeInTheDocument();
+    expect(screen.getByText('Reset')).toBeInTheDocument();
+  });
+
+  it('handles reset button clicks', () => {
+    const { rerender } = render(<HeartPage />);
+    const resetButton = screen.getByText('Reset');
+    fireEvent.click(resetButton);
+    rerender(<HeartPage />);
+    expect(screen.getByText('Back Home')).toBeInTheDocument();
+  });
+
+  it('responds to window resize', () => {
+    render(<HeartPage />);
+    global.innerWidth = 500;
+    fireEvent(window, new Event('resize'));
+    expect(screen.getByText('Back Home')).toBeInTheDocument();
+  });
+
+  it('should call onInteract when the heart is dragged', () => {
+    render(<HeartPage />);
+    const rigidBody = screen.getAllByTestId('rigidbody')[0];
+    fireEvent.mouseDown(rigidBody);
+  });
+
+  it('renders Sparkles component with default number of points', () => {
+    render(<HeartPage />);
+    const points = screen.getByTestId('points');
+    expect(points).toBeInTheDocument();
+    // Default count is 200
+    expect(points.dataset.positionsLength).toBe(String(200 * 3));
+  });
+
+  it('renders the Heart3D component with the names', () => {
+    render(<HeartPage />);
+    expect(screen.getAllByText('Abbi').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Fred').length).toBeGreaterThan(0);
+  });
+
+  it('breaks when colliding with force and reforms after a timeout', () => {
+    jest.useFakeTimers();
+    render(<HeartPage />);
+
+    expect(onContactForceCallback).toBeDefined();
+
+    act(() => {
+        onContactForceCallback({ totalForceMagnitude: 300 });
+    });
+
+    expect(mockRigidBodyApi.setBodyType).toHaveBeenCalledWith(RigidBodyType.Fixed, true);
+
+    act(() => {
+        jest.advanceTimersByTime(3000);
+    });
+
+    expect(mockRigidBodyApi.setBodyType).toHaveBeenCalledWith(RigidBodyType.Dynamic, true);
+    jest.useRealTimers();
+  });
+
+  it('renders the ScreenBounds component with four walls', () => {
+    render(<HeartPage />);
+    const colliders = screen.getAllByTestId('cuboid-collider');
+    expect(colliders.length).toBe(4);
+  });
+});

--- a/src/app/things-to-do/__tests__/page.test.tsx
+++ b/src/app/things-to-do/__tests__/page.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ThingsToDoPage from '../page';
+
+// Mock the ThingsToDoList component
+jest.mock('../components/ThingsToDoList', () => {
+  return function DummyThingsToDoList() {
+    return <div data-testid="things-to-do-list" />;
+  };
+});
+
+describe('ThingsToDoPage', () => {
+  it('renders the main heading', () => {
+    render(<ThingsToDoPage />);
+    expect(screen.getByRole('heading', { name: /Things to Do in Rochester/i })).toBeInTheDocument();
+  });
+
+  it('renders the ThingsToDoList component', () => {
+    render(<ThingsToDoPage />);
+    expect(screen.getByTestId('things-to-do-list')).toBeInTheDocument();
+  });
+});

--- a/src/app/things-to-do/components/__tests__/ThingsToDoCard.test.tsx
+++ b/src/app/things-to-do/components/__tests__/ThingsToDoCard.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ThingsToDoCard from '../ThingsToDoCard';
+import { Attraction } from '@/data/things-to-do';
+
+const mockAttraction: Attraction = {
+  name: 'Test Attraction',
+  description: 'A great place to visit.',
+  image: '/images/test.jpg',
+  website: 'https://example.com',
+  directions: 'https://maps.google.com',
+  category: 'museum',
+  latitude: 44.0232,
+  longitude: -92.4679,
+};
+
+describe('ThingsToDoCard', () => {
+  it('renders the attraction details correctly', () => {
+    render(<ThingsToDoCard attraction={mockAttraction} />);
+
+    expect(screen.getByText('Test Attraction')).toBeInTheDocument();
+    expect(screen.getByText('A great place to visit.')).toBeInTheDocument();
+    expect(screen.getByAltText('Test Attraction')).toBeInTheDocument();
+  });
+
+  it('has correct links for website and directions', () => {
+    render(<ThingsToDoCard attraction={mockAttraction} />);
+
+    const websiteLink = screen.getByText('Website').closest('a');
+    expect(websiteLink).toHaveAttribute('href', 'https://example.com');
+    expect(websiteLink).toHaveAttribute('target', '_blank');
+
+    const directionsLink = screen.getByText('Directions').closest('a');
+    expect(directionsLink).toHaveAttribute('href', 'https://maps.google.com');
+    expect(directionsLink).toHaveAttribute('target', '_blank');
+  });
+
+  it('renders a placeholder image if no image is provided', () => {
+    const attractionWithoutImage = { ...mockAttraction, image: '' };
+    render(<ThingsToDoCard attraction={attractionWithoutImage} />);
+    const image = screen.getByAltText('Test Attraction') as HTMLImageElement;
+    // The src will be encoded, so we check for the presence of the placeholder filename
+    expect(image.src).toContain(encodeURIComponent('/images/placeholder.png'));
+  });
+});

--- a/src/app/things-to-do/components/__tests__/ThingsToDoList.test.tsx
+++ b/src/app/things-to-do/components/__tests__/ThingsToDoList.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ThingsToDoList from '../ThingsToDoList';
+import { attractions } from '@/data/things-to-do';
+
+jest.mock('../ThingsToDoMap', () => () => <div data-testid="things-to-do-map" />);
+
+describe('ThingsToDoList', () => {
+  it('renders all attractions by default', () => {
+    render(<ThingsToDoList />);
+    const attractionCards = screen.getAllByText(/Directions/);
+    expect(attractionCards.length).toBe(attractions.length);
+  });
+
+  it('filters attractions when a category is clicked', () => {
+    render(<ThingsToDoList />);
+
+    const foodButton = screen.getByText('Food');
+    fireEvent.click(foodButton);
+
+    const foodAttractions = attractions.filter(a => a.category === 'food');
+    const attractionCards = screen.getAllByText(/Directions/);
+    expect(attractionCards.length).toBe(foodAttractions.length);
+  });
+
+  it('shows all attractions when "all" category is clicked', () => {
+    render(<ThingsToDoList />);
+
+    // First filter to something else
+    const foodButton = screen.getByText('Food');
+    fireEvent.click(foodButton);
+
+    // Then click "all"
+    const allButton = screen.getByText('All');
+    fireEvent.click(allButton);
+
+    const attractionCards = screen.getAllByText(/Directions/);
+    expect(attractionCards.length).toBe(attractions.length);
+  });
+});

--- a/src/app/things-to-do/components/__tests__/ThingsToDoList.test.tsx
+++ b/src/app/things-to-do/components/__tests__/ThingsToDoList.test.tsx
@@ -3,7 +3,11 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import ThingsToDoList from '../ThingsToDoList';
 import { attractions } from '@/data/things-to-do';
 
-jest.mock('../ThingsToDoMap', () => () => <div data-testid="things-to-do-map" />);
+jest.mock('../ThingsToDoMap', () => {
+    const MockThingsToDoMap = () => <div data-testid="things-to-do-map" />;
+    MockThingsToDoMap.displayName = 'MockThingsToDoMap';
+    return MockThingsToDoMap;
+});
 
 describe('ThingsToDoList', () => {
   it('renders all attractions by default', () => {

--- a/src/app/things-to-do/components/__tests__/ThingsToDoMap.test.tsx
+++ b/src/app/things-to-do/components/__tests__/ThingsToDoMap.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ThingsToDoMap from '../ThingsToDoMap';
+import { attractions } from '@/data/things-to-do';
+
+jest.mock('react-leaflet', () => ({
+  MapContainer: ({ children }: { children: React.ReactNode }) => <div data-testid="map-container">{children}</div>,
+  TileLayer: () => <div data-testid="tile-layer" />,
+  Marker: ({ children }: { children: React.ReactNode }) => <div data-testid="marker">{children}</div>,
+  Popup: ({ children }: { children: React.ReactNode }) => <div data-testid="popup">{children}</div>,
+}));
+
+describe('ThingsToDoMap', () => {
+  it('renders the map and markers', () => {
+    render(<ThingsToDoMap attractions={attractions} />);
+
+    expect(screen.getByTestId('map-container')).toBeInTheDocument();
+    expect(screen.getByTestId('tile-layer')).toBeInTheDocument();
+
+    const markers = screen.getAllByTestId('marker');
+    expect(markers).toHaveLength(attractions.length);
+  });
+});

--- a/src/components/__tests__/PhotoGrid.test.tsx
+++ b/src/components/__tests__/PhotoGrid.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import PhotoGrid from '../PhotoGrid';
+import Lightbox from '../Lightbox';
+import { GalleryImage } from '../Gallery';
+
+const mockImages: GalleryImage[] = [
+  { src: '/image1.jpg', alt: 'Image 1' },
+  { src: '/image2.jpg', alt: 'Image 2' },
+  { src: '/image3.jpg', alt: 'Image 3' },
+];
+
+// Mock useInView to always be in view
+jest.mock('react-intersection-observer', () => ({
+  useInView: () => ({
+    ref: jest.fn(),
+    inView: true,
+  }),
+}));
+
+describe('PhotoGrid', () => {
+  it('renders the correct number of images', () => {
+    render(<PhotoGrid images={mockImages} />);
+    const images = screen.getAllByRole('img');
+    expect(images).toHaveLength(mockImages.length);
+  });
+
+  it('opens the lightbox when an image is clicked', () => {
+    render(<PhotoGrid images={mockImages} />);
+    const images = screen.getAllByRole('img');
+    fireEvent.click(images[1]);
+
+    const lightbox = screen.getByRole('dialog');
+    expect(lightbox).toBeInTheDocument();
+
+    const lightboxImage = within(lightbox).getByAltText('Image 2');
+    expect(lightboxImage).toBeInTheDocument();
+  });
+});
+
+describe('Lightbox', () => {
+  const mockOnClose = jest.fn();
+  const mockOnNext = jest.fn();
+  const mockOnPrev = jest.fn();
+
+  beforeEach(() => {
+    mockOnClose.mockClear();
+    mockOnNext.mockClear();
+    mockOnPrev.mockClear();
+  });
+
+  it('displays the correct image', () => {
+    render(
+      <Lightbox
+        images={mockImages}
+        currentIndex={1}
+        onClose={mockOnClose}
+        onNext={mockOnNext}
+        onPrev={mockOnPrev}
+      />
+    );
+    const image = screen.getByAltText('Image 2');
+    expect(image).toBeInTheDocument();
+  });
+
+  it('calls onClose when the close button is clicked', () => {
+    render(
+      <Lightbox
+        images={mockImages}
+        currentIndex={0}
+        onClose={mockOnClose}
+        onNext={mockOnNext}
+        onPrev={mockOnPrev}
+      />
+    );
+    const closeButton = screen.getByLabelText('Close');
+    fireEvent.click(closeButton);
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when the background is clicked', () => {
+    render(
+      <Lightbox
+        images={mockImages}
+        currentIndex={0}
+        onClose={mockOnClose}
+        onNext={mockOnNext}
+        onPrev={mockOnPrev}
+      />
+    );
+    const background = screen.getByRole('dialog');
+    fireEvent.click(background);
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onNext when the next button is clicked', () => {
+    render(
+      <Lightbox
+        images={mockImages}
+        currentIndex={0}
+        onClose={mockOnClose}
+        onNext={mockOnNext}
+        onPrev={mockOnPrev}
+      />
+    );
+    const nextButton = screen.getByLabelText('Next image');
+    fireEvent.click(nextButton);
+    expect(mockOnNext).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onPrev when the previous button is clicked', () => {
+    render(
+      <Lightbox
+        images={mockImages}
+        currentIndex={0}
+        onClose={mockOnClose}
+        onNext={mockOnNext}
+        onPrev={mockOnPrev}
+      />
+    );
+    const prevButton = screen.getByLabelText('Previous image');
+    fireEvent.click(prevButton);
+    expect(mockOnPrev).toHaveBeenCalledTimes(1);
+  });
+
+  it('responds to keyboard events', () => {
+    render(
+      <Lightbox
+        images={mockImages}
+        currentIndex={0}
+        onClose={mockOnClose}
+        onNext={mockOnNext}
+        onPrev={mockOnPrev}
+      />
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(document, { key: 'ArrowRight' });
+    expect(mockOnNext).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(document, { key: 'ArrowLeft' });
+    expect(mockOnPrev).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/registry/hooks/__tests__/useRegistry.test.tsx
+++ b/src/features/registry/hooks/__tests__/useRegistry.test.tsx
@@ -1,0 +1,206 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useRegistry } from '../useRegistry';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { RegistryItem } from '../../types';
+import fetchMock from 'jest-fetch-mock';
+import { checkAdminClient } from '@/utils/adminAuth.client';
+
+// Mock next/navigation
+const mockPush = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+// Mock admin check
+jest.mock('@/utils/adminAuth.client');
+const mockedCheckAdminClient = checkAdminClient as jest.Mock;
+
+
+// Mock window.confirm and window.alert
+global.confirm = jest.fn(() => true);
+global.alert = jest.fn();
+
+const createTestQueryClient = () => new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
+
+const wrapper = (client: QueryClient) => ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={client}>
+    {children}
+  </QueryClientProvider>
+);
+
+const mockItems: RegistryItem[] = [
+    { id: '1', name: 'Item 1', category: 'Category A', price: 100, purchased: false, isGroupGift: false, amountContributed: 0, contributors: [], imageUrl: '', description: '' },
+    { id: '2', name: 'Item 2', category: 'Category B', price: 200, purchased: true, isGroupGift: false, amountContributed: 0, contributors: [], purchaserName: 'John Doe', imageUrl: '', description: '' },
+    { id: '3', name: 'Item 3', category: 'Category A', price: 300, purchased: false, isGroupGift: true, amountContributed: 150, contributors: [], imageUrl: '', description: '' },
+];
+
+describe('useRegistry', () => {
+    let queryClient: QueryClient;
+
+  beforeEach(() => {
+    fetchMock.enableMocks();
+    fetchMock.resetMocks();
+    mockedCheckAdminClient.mockResolvedValue(false);
+    queryClient = createTestQueryClient();
+  });
+
+  it('should fetch registry items and return initial state', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify(mockItems));
+    const { result } = renderHook(() => useRegistry(), { wrapper: wrapper(queryClient) });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.items).toEqual(mockItems);
+    expect(result.current.isAdmin).toBe(false);
+  });
+
+  it('should handle card click and open modal', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify(mockItems));
+    const { result } = renderHook(() => useRegistry(), { wrapper: wrapper(queryClient) });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    const item = result.current.items[0];
+
+    act(() => {
+      result.current.handleCardClick(item);
+    });
+
+    expect(result.current.selectedItem).toEqual(item);
+    expect(result.current.isModalOpen).toBe(true);
+  });
+
+  it('should not open modal for purchased item', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify(mockItems));
+    const { result } = renderHook(() => useRegistry(), { wrapper: wrapper(queryClient) });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    const item = result.current.items[1];
+
+    act(() => {
+      result.current.handleCardClick(item);
+    });
+
+    expect(result.current.selectedItem).toBeNull();
+    expect(result.current.isModalOpen).toBe(false);
+  });
+
+  it('should handle modal close', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify(mockItems));
+    const { result } = renderHook(() => useRegistry(), { wrapper: wrapper(queryClient) });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+        result.current.handleCardClick(result.current.items[0]);
+    });
+
+    expect(result.current.isModalOpen).toBe(true);
+
+    act(() => {
+        result.current.handleCloseModal();
+    });
+
+    expect(result.current.isModalOpen).toBe(false);
+    expect(result.current.selectedItem).toBeNull();
+  });
+
+  it('should handle edit', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify(mockItems));
+    const { result } = renderHook(() => useRegistry(), { wrapper: wrapper(queryClient) });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+        result.current.handleEdit('1');
+    });
+
+    expect(mockPush).toHaveBeenCalledWith('/registry/edit-item/1');
+  });
+
+  it('should handle delete', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({}));
+    const { result } = renderHook(() => useRegistry(), { wrapper: wrapper(queryClient) });
+
+    await act(async () => {
+        result.current.handleDelete('1');
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/registry/items/1', { method: 'DELETE' });
+  });
+
+  it('should handle contribution', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({}));
+    fetchMock.mockResponseOnce(JSON.stringify(mockItems));
+    const { result } = renderHook(() => useRegistry(), { wrapper: wrapper(queryClient) });
+
+    await act(async () => {
+        await result.current.handleContribute('1', 'Jane Doe', 50);
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/registry/contribute', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ itemId: '1', purchaserName: 'Jane Doe', amount: 50 }),
+    });
+  });
+
+  it('should filter items by category', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify(mockItems));
+    const { result } = renderHook(() => useRegistry(), { wrapper: wrapper(queryClient) });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+        result.current.setCategoryFilter(['Category B']);
+    });
+
+    expect(result.current.filteredItems.length).toBe(1);
+    expect(result.current.filteredItems[0].id).toBe('2');
+  });
+
+  it('should filter by price range', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify(mockItems));
+    const { result } = renderHook(() => useRegistry(), { wrapper: wrapper(queryClient) });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+        result.current.setPriceRange([150, 250]);
+    });
+
+    expect(result.current.filteredItems.length).toBe(1);
+    expect(result.current.filteredItems[0].id).toBe('2');
+  });
+
+  it('should filter by group gifts only', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify(mockItems));
+    const { result } = renderHook(() => useRegistry(), { wrapper: wrapper(queryClient) });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+        result.current.setShowGroupGiftsOnly(true);
+    });
+
+    expect(result.current.filteredItems.length).toBe(1);
+    expect(result.current.filteredItems[0].id).toBe('3');
+  });
+
+  it('should filter by available only', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify(mockItems));
+    const { result } = renderHook(() => useRegistry(), { wrapper: wrapper(queryClient) });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+        result.current.setShowAvailableOnly(true);
+    });
+
+    expect(result.current.filteredItems.length).toBe(2);
+    expect(result.current.filteredItems.map(i => i.id)).toEqual(['1', '3']);
+  });
+});

--- a/src/features/registry/hooks/__tests__/useRegistry.test.tsx
+++ b/src/features/registry/hooks/__tests__/useRegistry.test.tsx
@@ -31,11 +31,15 @@ const createTestQueryClient = () => new QueryClient({
   },
 });
 
-const wrapper = (client: QueryClient) => ({ children }: { children: React.ReactNode }) => (
-  <QueryClientProvider client={client}>
-    {children}
-  </QueryClientProvider>
-);
+const wrapper = (client: QueryClient) => {
+    const Wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={client}>
+            {children}
+        </QueryClientProvider>
+    );
+    Wrapper.displayName = 'QueryClientWrapper';
+    return Wrapper;
+};
 
 const mockItems: RegistryItem[] = [
     { id: '1', name: 'Item 1', category: 'Category A', price: 100, purchased: false, isGroupGift: false, amountContributed: 0, contributors: [], imageUrl: '', description: '' },


### PR DESCRIPTION
This commit adds a significant number of new tests to improve the overall test coverage of the application.

The following components and pages now have improved test coverage:
- `sitemap.ts`
- `heart/page.tsx`
- `things-to-do/page.tsx` and its components
- `components/PhotoGrid.tsx` and `components/Lightbox.tsx`
- `features/registry/hooks/useRegistry.ts`

The tests cover rendering, user interactions, and edge cases. Mocks have been used for external dependencies like `react-leaflet`, `react-three-fiber`, and `next/navigation`.
