### PR TITLE
Potential fix for code scanning alert no. 5: Server-side request forgery

### DIFF
--- a/src/features/registry/api/scrape.ts
+++ b/src/features/registry/api/scrape.ts
@@ -30,10 +30,16 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'URL is required and must be a string' }, { status: 400 });
     }
 
+    let parsedUrl: URL;
     try {
-      new URL(url);
+      parsedUrl = new URL(url);
     } catch {
       return NextResponse.json({ error: 'Invalid URL format' }, { status: 400 });
+    }
+
+    // Only allow HTTP(S) URLs to prevent SSRF via unexpected schemes
+    if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+      return NextResponse.json({ error: 'Invalid URL protocol' }, { status: 400 });
     }
 
     // SSRF Protection: Ensure URL does not point to a private IP
@@ -65,7 +71,6 @@ export async function POST(request: Request) {
     }
 
     // Fallback for Amazon: If no image was found, fetch HTML and parse with Cheerio
-    const parsedUrl = new URL(url);
     const hostname = parsedUrl.hostname;
     const isAmazonDomain = (
       hostname === 'amazon.com' ||
@@ -73,7 +78,12 @@ export async function POST(request: Request) {
     );
     if (!image && isAmazonDomain) {
       try {
-        const response = await fetch(url);
+        // Restrict fallback fetch to HTTPS on allowed Amazon domains using the validated URL
+        if (parsedUrl.protocol !== 'https:') {
+          throw new Error('Amazon fallback only supports HTTPS URLs');
+        }
+
+        const response = await fetch(parsedUrl.toString());
         const html = await response.text();
         const $ = cheerio.load(html);
 


### PR DESCRIPTION
Potential fix for [https://github.com/fderuiter/wedding_website/security/code-scanning/5](https://github.com/fderuiter/wedding_website/security/code-scanning/5)

In general, to fix SSRF issues you must ensure that user input cannot arbitrarily control the hostname (and ideally protocol/port) of outbound HTTP requests. This is usually done by: (1) validating and parsing the URL, (2) enforcing a strict allow‑list of permitted hostnames (or patterns) and schemes, and (3) optionally blocking private or internal IP ranges via DNS resolution checks like `isPrivateUrl`.

For this specific code, the most targeted and non‑breaking fix is to enforce that the fallback `fetch(url)` can only be executed for `https` URLs whose hostname is exactly `amazon.com` or an `amazon.com` subdomain. We already compute `parsedUrl` and `hostname` and determine `isAmazonDomain`; we can reuse that parsing to (a) reject non-HTTP(S) schemes up-front and (b) guard the `fetch` call using the parsed URL rather than the raw string. The best approach with minimal behavioral change is:

1. Tighten initial validation right after `new URL(url)` to ensure only `http:` or `https:` schemes are allowed; anything else returns 400.
2. In the Amazon fallback branch, remove the direct `fetch(url)` on the raw string and instead:
   - Reuse the existing `parsedUrl` object.
   - Enforce `parsedUrl.protocol === 'https:'` for the fallback (Amazon product pages are expected to be HTTPS; this avoids mixed-scheme surprises).
   - Use `fetch(parsedUrl.toString())`, which is equivalent to the original behavior for valid URLs but makes it explicit we are using the parsed, validated URL.
3. Optionally, add an explicit comment documenting that we are intentionally restricting the Amazon fallback to `https://*.amazon.com` and that broader SSRF protection is handled by `isPrivateUrl`.

All edits occur within `src/features/registry/api/scrape.ts`. We do not need new imports or helpers; we only add some conditional checks and slightly adjust the `fetch` call. The observable behavior for normal `https://amazon.com/...` URLs remains the same, while dangerous schemes or hostnames will now be rejected earlier.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
