### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded fallback secret in admin authentication

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The admin login route used direct string comparison (or simple hashing) for the password, which is vulnerable to brute-force and timing attacks.
 **Learning:** For password verification, simple hashing (like SHA-256) is insufficient due to speed. Timing attacks are also a risk with direct comparison.
 **Prevention:** Use `bcrypt` for password storage and verification. It handles salting automatically and is computationally expensive, resisting brute-force attacks. It also performs constant-time comparison.
+
+## 2024-05-25 - Hardcoded Fallback Secret in Admin Authentication
+**Vulnerability:** The admin JWT token signing process in `src/utils/adminAuth.server.ts` used a hardcoded fallback secret (`'fallback-secret-for-dev'`) if the `ADMIN_PASSWORD` environment variable was missing. This would allow an attacker to bypass authentication by forging tokens with the known fallback secret.
+**Learning:** Hardcoded fallback secrets in authentication mechanisms are a severe security risk, even if intended only for development. If they inadvertently make it into production (e.g. due to missing environment variables), they provide a trivial bypass.
+**Prevention:** Generate a cryptographically secure random secret dynamically on server startup (e.g., `crypto.randomBytes(32).toString('hex')`) if a configuration secret is missing. This ensures any tokens generated are valid only for that specific server process, invalidating them on restart, and preventing attackers from forging tokens.

--- a/src/utils/adminAuth.server.ts
+++ b/src/utils/adminAuth.server.ts
@@ -6,7 +6,7 @@ const ADMIN_COOKIE = 'admin_auth';
 
 // Use the admin password hash as the secret for signing tokens.
 // In a real app, use a dedicated SESSION_SECRET environment variable.
-const SECRET = process.env.ADMIN_PASSWORD || 'fallback-secret-for-dev';
+const SECRET = process.env.ADMIN_PASSWORD || crypto.randomBytes(32).toString('hex');
 
 interface AdminTokenPayload {
   isAdmin: boolean;


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The admin JWT authentication (`src/utils/adminAuth.server.ts`) relied on a hardcoded fallback string (`'fallback-secret-for-dev'`) for signing tokens if the `ADMIN_PASSWORD` environment variable was missing or unconfigured. 
🎯 **Impact:** An attacker who knows this fallback secret (which is publicly visible in the source code) could forge valid admin tokens to bypass the admin authentication layer entirely.
🔧 **Fix:** Replaced the hardcoded fallback with a dynamic, cryptographically secure 32-byte random hex string generated using `crypto.randomBytes()`. This ensures that even in a fallback scenario, tokens are signed with a securely randomized key valid only for the lifespan of the running server instance.
✅ **Verification:** Verified via `npm run test` and `npm run build` that the application functions normally and passes all tests with the dynamic secret generation.

---
*PR created automatically by Jules for task [14421948293669248613](https://jules.google.com/task/14421948293669248613) started by @fderuiter*