### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -67,6 +67,7 @@ export default function Navbar({ isAdmin, handleLogout, headerRef }: NavbarProps
                       ? 'text-white bg-rose-500'
                       : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
                   }`}
+                  aria-current={pathname === link.href ? 'page' : undefined}
                 >
                   {link.label}
                 </Link>
@@ -121,6 +122,7 @@ export default function Navbar({ isAdmin, handleLogout, headerRef }: NavbarProps
                     ? 'text-white bg-rose-500'
                     : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
                 }`}
+                aria-current={pathname === link.href ? 'page' : undefined}
               >
                 {link.label}
               </Link>


### PR DESCRIPTION
🎨 Palette: Add aria-current to active navigation links

### 💡 What:
Added the `aria-current="page"` attribute to navigation links in both the desktop and mobile menus when they correspond to the currently active route.

### 🎯 Why:
This improves the experience for users utilizing screen readers. Previously, active links were only distinguished visually (by a rose background). Now, screen readers will programmatically announce which link represents the current page.

### 📸 Before/After:
*Visuals remain unchanged, but semantics are enhanced.*

### ♿ Accessibility:
- Added `aria-current="page"` to `<Link>` components in `Navbar.tsx` based on the `pathname`.

---
*PR created automatically by Jules for task [10768225112568349931](https://jules.google.com/task/10768225112568349931) started by @fderuiter*