### PR TITLE
🎨 Palette: Make PhotoGrid images keyboard accessible

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/PhotoGrid.tsx
+++ b/src/components/PhotoGrid.tsx
@@ -89,8 +89,17 @@ const GridImage = memo<GridImageProps>(({
 
   return (
     <div
-      className="aspect-square relative cursor-pointer bg-gray-200 dark:bg-gray-800 rounded-lg overflow-hidden"
+      className="aspect-square relative cursor-pointer bg-gray-200 dark:bg-gray-800 rounded-lg overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-rose-500"
       onClick={() => openLightbox(index)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          openLightbox(index);
+        }
+      }}
+      tabIndex={0}
+      role="button"
+      aria-label={`View ${image.alt}`}
     >
       <Image
         src={image.src}

--- a/src/components/__tests__/PhotoGrid.test.tsx
+++ b/src/components/__tests__/PhotoGrid.test.tsx
@@ -30,6 +30,26 @@ describe('PhotoGrid', () => {
     const lightboxImage = within(lightbox).getByAltText('Image 2');
     expect(lightboxImage).toBeInTheDocument();
   });
+
+  it('opens the lightbox when an image receives Enter or Space key press', () => {
+    render(<PhotoGrid images={mockImages} />);
+    const images = screen.getAllByRole('button');
+    // Test Enter
+    fireEvent.keyDown(images[1], { key: 'Enter' });
+    let lightbox = screen.getByRole('dialog');
+    expect(lightbox).toBeInTheDocument();
+
+    // Close lightbox
+    const closeButton = screen.getByLabelText('Close');
+    fireEvent.click(closeButton);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    // Test Space
+    fireEvent.keyDown(images[1], { key: ' ' });
+    lightbox = screen.getByRole('dialog');
+    expect(lightbox).toBeInTheDocument();
+  });
+
 });
 
 describe('Lightbox', () => {


### PR DESCRIPTION
💡 **What**: Added full keyboard accessibility and screen reader support to the interactive images in the `PhotoGrid` component.
🎯 **Why**: The photos in the grid act as buttons (opening a lightbox on click) but were using a plain `div` with an `onClick` handler. This made them inaccessible to users navigating via keyboard (they couldn't be focused or activated) and confusing for screen reader users (no role or label).
♿ **Accessibility**: 
- Added `role="button"` and `tabIndex={0}` for focusability.
- Added descriptive `aria-label`.
- Added keyboard activation on `Enter` and `Space`.
- Added visual focus rings using existing design tokens (`focus-visible:ring-rose-500`).

---
*PR created automatically by Jules for task [4163673442028187159](https://jules.google.com/task/4163673442028187159) started by @fderuiter*