### PR TITLE
🎨 Palette: Refine checkbox focus styles in registry filters

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/features/registry/pages/index.tsx
+++ b/src/features/registry/pages/index.tsx
@@ -112,7 +112,7 @@ export default function RegistryPage() {
               id="group-gifts-only"
               checked={showGroupGiftsOnly}
               onChange={(e) => setShowGroupGiftsOnly(e.target.checked)}
-              className="h-4 w-4 text-rose-600 border-gray-300 rounded focus:ring-rose-500"
+              className="h-4 w-4 text-rose-600 border-gray-300 rounded focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:outline-none focus-visible:ring-offset-2"
             />
             <label htmlFor="group-gifts-only" className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
               Show only group gifts
@@ -124,7 +124,7 @@ export default function RegistryPage() {
               id="available-only"
               checked={showAvailableOnly}
               onChange={(e) => setShowAvailableOnly(e.target.checked)}
-              className="h-4 w-4 text-rose-600 border-gray-300 rounded focus:ring-rose-500"
+              className="h-4 w-4 text-rose-600 border-gray-300 rounded focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:outline-none focus-visible:ring-offset-2"
             />
             <label htmlFor="available-only" className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
               Show only available gifts


### PR DESCRIPTION
## 💡 What
Replaced generic `focus:ring-rose-500` classes with `focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:outline-none focus-visible:ring-offset-2` on the checkboxes in the Registry filters (`src/features/registry/pages/index.tsx`).

## 🎯 Why
The generic `focus` class triggers on both keyboard navigation and mouse clicks. When a user clicks the checkbox with a mouse, the focus ring lingers, which can be visually confusing or unpolished. Using `focus-visible` ensures that the focus ring only appears when navigating via keyboard (e.g., using Tab), providing essential accessibility without compromising the mouse UX.

## 📸 Before/After
*   **Before:** Clicking the checkbox with a mouse leaves a pink ring around it until the user clicks elsewhere.
*   **After:** Clicking with a mouse shows no ring, but tabbing to the checkbox shows a clear, accessible pink focus ring with a proper offset.

## ♿ Accessibility
This change maintains full accessibility for keyboard users by providing a clear, high-contrast focus ring, while improving the visual experience for mouse users.

---
*PR created automatically by Jules for task [9873154314918501046](https://jules.google.com/task/9873154314918501046) started by @fderuiter*