### PR TITLE
🎨 Palette: [UX improvement] Standardize focus states in RegistryItemForm

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/features/registry/components/RegistryItemForm.tsx
+++ b/src/features/registry/components/RegistryItemForm.tsx
@@ -119,13 +119,13 @@ const RegistryItemForm: React.FC<RegistryItemFormProps> = ({
               value={scrapeUrl}
               onChange={e => setScrapeUrl(e.target.value)}
               placeholder="https://..."
-              className="flex-1 rounded border-gray-300 dark:border-gray-600 p-2 border bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100"
+              className="flex-1 rounded border-gray-300 dark:border-gray-600 p-2 border bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-2"
               disabled={scrapeLoading}
             />
             <button
               type="button"
               onClick={handleScrape}
-              className={`bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded flex items-center justify-center ${scrapeLoading ? 'opacity-75 cursor-not-allowed' : ''}`}
+              className={`bg-rose-600 hover:bg-rose-700 text-white px-3 py-1 rounded flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-2 ${scrapeLoading ? 'opacity-75 cursor-not-allowed' : ''}`}
               disabled={scrapeLoading || !scrapeUrl}
               aria-busy={scrapeLoading}
             >
@@ -144,38 +144,38 @@ const RegistryItemForm: React.FC<RegistryItemFormProps> = ({
       )}
       <div>
         <label htmlFor="name" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Item Name <span className="text-red-500">*</span></label>
-        <input type="text" id="name" name="name" value={values.name || ''} onChange={handleChange} required aria-required="true" className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100" />
+        <input type="text" id="name" name="name" value={values.name || ''} onChange={handleChange} required aria-required="true" className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-2 sm:text-sm p-2 border bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100" />
       </div>
       <div>
         <label htmlFor="description" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Description:</label>
-        <textarea id="description" name="description" value={values.description || ''} onChange={handleChange} rows={3} className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100"></textarea>
+        <textarea id="description" name="description" value={values.description || ''} onChange={handleChange} rows={3} className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-2 sm:text-sm p-2 border bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100"></textarea>
       </div>
       <div>
         <label htmlFor="price" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Price ($) <span className="text-red-500">*</span></label>
-        <input type="number" id="price" name="price" value={values.price ?? ''} onChange={handleChange} step="0.01" required aria-required="true" className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100" />
+        <input type="number" id="price" name="price" value={values.price ?? ''} onChange={handleChange} step="0.01" required aria-required="true" className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-2 sm:text-sm p-2 border bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100" />
       </div>
       <div>
         <label htmlFor="quantity" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Quantity <span className="text-red-500">*</span></label>
-        <input type="number" id="quantity" name="quantity" value={values.quantity ?? 1} onChange={handleChange} required aria-required="true" className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100" />
+        <input type="number" id="quantity" name="quantity" value={values.quantity ?? 1} onChange={handleChange} required aria-required="true" className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-2 sm:text-sm p-2 border bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100" />
       </div>
       <div>
         <label htmlFor="category" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Category <span className="text-red-500">*</span></label>
-        <input type="text" id="category" name="category" value={values.category || ''} onChange={handleChange} required aria-required="true" className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100" />
+        <input type="text" id="category" name="category" value={values.category || ''} onChange={handleChange} required aria-required="true" className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-2 sm:text-sm p-2 border bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100" />
       </div>
       <div>
         <label htmlFor="image" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Image URL:</label>
-        <input type="url" id="image" name="image" value={values.image || ''} onChange={handleChange} placeholder="https://..." className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100" />
+        <input type="url" id="image" name="image" value={values.image || ''} onChange={handleChange} placeholder="https://..." className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-2 sm:text-sm p-2 border bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100" />
       </div>
       <div>
         <label htmlFor="vendorUrl" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Vendor/Product URL:</label>
-        <input type="url" id="vendorUrl" name="vendorUrl" value={values.vendorUrl || ''} onChange={handleChange} placeholder="https://..." className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100" />
+        <input type="url" id="vendorUrl" name="vendorUrl" value={values.vendorUrl || ''} onChange={handleChange} placeholder="https://..." className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-2 sm:text-sm p-2 border bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100" />
       </div>
       <div className="flex items-center">
-        <input type="checkbox" id="isGroupGift" name="isGroupGift" checked={!!values.isGroupGift} onChange={handleChange} className="h-4 w-4 text-indigo-600 border-gray-300 dark:border-gray-600 rounded focus:ring-indigo-500" />
+        <input type="checkbox" id="isGroupGift" name="isGroupGift" checked={!!values.isGroupGift} onChange={handleChange} className="h-4 w-4 text-rose-600 border-gray-300 dark:border-gray-600 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-2" />
         <label htmlFor="isGroupGift" className="ml-2 block text-sm text-gray-900 dark:text-gray-100">Allow Group Gifting?</label>
       </div>
       {formError && <p className="text-red-500 text-sm mt-2">{formError}</p>}
-      <button type="submit" className={`inline-flex justify-center items-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 ${isSubmitting ? 'opacity-75 cursor-not-allowed' : ''}`} disabled={isSubmitting} aria-busy={isSubmitting}>
+      <button type="submit" className={`inline-flex justify-center items-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-rose-600 hover:bg-rose-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-rose-500 ${isSubmitting ? 'opacity-75 cursor-not-allowed' : ''}`} disabled={isSubmitting} aria-busy={isSubmitting}>
         {isSubmitting && <Loader2 className="animate-spin mr-2 h-4 w-4" />}
         {submitLabel || (mode === 'add' ? 'Add Item' : 'Save Changes')}
       </button>


### PR DESCRIPTION
### 💡 What:
Updated the focus styling on all interactive elements in `RegistryItemForm.tsx` from generic defaults (like `focus:ring-indigo-500`) to the project's standardized, keyboard-only focus ring (`focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:outline-none focus-visible:ring-offset-2`). Additionally unified the button and checkbox colors from `blue/indigo` to `rose`.

### 🎯 Why:
This improves accessibility by providing a clear, high-contrast focus indicator for keyboard users while eliminating visual noise for mouse clicks. It also ensures visual consistency with the rest of the application's design system.

### ♿ Accessibility:
Replaced `focus` classes with `focus-visible`, meaning the focus rings will only show for users navigating via keyboard (or screen reader), conforming to the latest UX best practices for interactive states.

---
*PR created automatically by Jules for task [8875415135172426862](https://jules.google.com/task/8875415135172426862) started by @fderuiter*