### PR TITLE
🎨 Palette: [UX improvement] Improve accessibility of "Learn more" links in WeddingPartyCard

### DIFF
--- a/src/components/WeddingPartyCard.tsx
+++ b/src/components/WeddingPartyCard.tsx
@@ -41,9 +41,10 @@ const WeddingPartyCard: React.FC<WeddingPartyCardProps> = ({ member }) => {
             href={member.link}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center text-rose-600 dark:text-rose-400 hover:text-rose-800 dark:hover:text-rose-200"
+            aria-label={`Learn more about ${member.name}`}
+            className="inline-flex items-center text-rose-600 dark:text-rose-400 hover:text-rose-800 dark:hover:text-rose-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-2 rounded"
           >
-            Learn more <ExternalLink className="ml-2 h-4 w-4" />
+            Learn more <ExternalLink className="ml-2 h-4 w-4" aria-hidden="true" />
           </a>
         )}
       </div>

--- a/src/components/__tests__/WeddingPartyCard.test.tsx
+++ b/src/components/__tests__/WeddingPartyCard.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import WeddingPartyCard from '../WeddingPartyCard';
+
+describe('WeddingPartyCard', () => {
+  const mockMember = {
+    name: 'Test Member',
+    role: 'Test Role',
+    bio: 'Test Bio',
+    photo: '/test-photo.jpg',
+    link: 'https://test-link.com',
+  };
+
+  it('renders member details', () => {
+    render(<WeddingPartyCard member={mockMember} />);
+    expect(screen.getByText('Test Member')).toBeInTheDocument();
+    expect(screen.getByText('Test Role')).toBeInTheDocument();
+    expect(screen.getByText('Test Bio')).toBeInTheDocument();
+  });
+
+  it('renders a link with a descriptive aria-label', () => {
+    render(<WeddingPartyCard member={mockMember} />);
+    const link = screen.getByRole('link', { name: 'Learn more about Test Member' });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'https://test-link.com');
+  });
+
+  it('hides the external link icon from screen readers', () => {
+    render(<WeddingPartyCard member={mockMember} />);
+    const icon = document.querySelector('svg');
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+  });
+});


### PR DESCRIPTION
### 💡 What
Added a contextual `aria-label` to the "Learn more" link on `WeddingPartyCard` components (e.g., `aria-label="Learn more about Emily Schultz"`). Also added visible focus styles (`focus-visible:ring-2`) and hid the trailing external link icon from screen readers (`aria-hidden="true"`).

### 🎯 Why
When navigating with a screen reader, a page full of identical "Learn more" links lacks context. By adding the member's name to the `aria-label`, users instantly know where the link will take them. Adding `focus-visible` ensures keyboard users can clearly see which link is currently focused.

### ♿ Accessibility
- **Screen Readers:** "Learn more" is now announced as "Learn more about [Member Name]".
- **Screen Readers:** The decorative `ExternalLink` icon is ignored, preventing confusing readouts.
- **Keyboard Navigation:** The link now features a distinct, rose-colored focus ring when navigated via the keyboard (Tab key).

### 📸 Before/After
*(Verified via Playwright screenshot. Keyboard focus ring now visible on links when tabbing through the grid).*

---
*PR created automatically by Jules for task [3531760851776154901](https://jules.google.com/task/3531760851776154901) started by @fderuiter*