### PR TITLE
🎨 Palette: Improve WeddingPartyCard link accessibility

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/WeddingPartyCard.tsx
+++ b/src/components/WeddingPartyCard.tsx
@@ -41,9 +41,10 @@ const WeddingPartyCard: React.FC<WeddingPartyCardProps> = ({ member }) => {
             href={member.link}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center text-rose-600 dark:text-rose-400 hover:text-rose-800 dark:hover:text-rose-200"
+            className="inline-flex items-center text-rose-600 dark:text-rose-400 hover:text-rose-800 dark:hover:text-rose-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-2 rounded"
+            aria-label={`Learn more about ${member.name}`}
           >
-            Learn more <ExternalLink className="ml-2 h-4 w-4" />
+            Learn more <ExternalLink className="ml-2 h-4 w-4" aria-hidden="true" />
           </a>
         )}
       </div>


### PR DESCRIPTION
**💡 What:** 
Added context-specific `aria-label`s to the "Learn more" links in `WeddingPartyCard`, hid the purely decorative `ExternalLink` icon from screen readers, and applied `focus-visible` states to ensure the link is clearly identifiable for keyboard users.

**🎯 Why:** 
When navigating using a screen reader's "Links List", a user encounters a series of identical "Learn more" links with no context. This makes it impossible to know which link goes to which person. Additionally, keyboard users had poor visual indication of focus when tabbing through the cards.

**📸 Before/After:** 
_After (Visual):_ Focused link now shows a clear `rose-500` outline.
_After (a11y tree):_ Screen reader parses "Learn more about [Name]".

**♿ Accessibility:**
- Contextualized generic link text using `aria-label`.
- Suppressed redundant icon readouts using `aria-hidden="true"`.
- Enhanced keyboard navigation visibility using `focus-visible` Tailwind classes.

---
*PR created automatically by Jules for task [9299048935930486911](https://jules.google.com/task/9299048935930486911) started by @fderuiter*